### PR TITLE
naming enterprise private key parameter to prevent wrong number of arguments

### DIFF
--- a/examples/jwt_auth.rb
+++ b/examples/jwt_auth.rb
@@ -7,6 +7,6 @@ require 'openssl'
 private_key = OpenSSL::PKey::RSA.new(File.read(ENV['JWT_SECRET_KEY_PATH']), ENV['JWT_SECRET_KEY_PASSWORD'])
 
 #make sure ENV['BOX_ENTERPRISE_ID'] and ENV['BOX_CLIENT_ID'] are set
-response = Boxr::get_enterprise_token(private_key)
+response = Boxr::get_enterprise_token(private_key:private_key)
 
 ap response


### PR DESCRIPTION
Hey I don't know Ruby but I'm using your library get enterprise tokens, and I have to name this private_key parameter to prevent an invalid arguments error: 

auth.rb:27:in `get_enterprise_token': wrong number of arguments (1 for 0) (ArgumentError)

Does this sound right? Or do you recommend always setting ENV['JWT_PRIVATE_KEY']?