### PR TITLE
Add password-protected shared links

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ delete_folder(folder, recursive: false, if_match: nil)
 
 copy_folder(folder, dest_folder, name: nil)
 
-create_shared_link_for_folder(folder, access: nil, unshared_at: nil, can_download: nil, can_preview: nil)
+create_shared_link_for_folder(folder, access: nil, unshared_at: nil, password: nil, can_download: nil, can_preview: nil)
 
 disable_shared_link_for_folder(folder)
 
@@ -207,7 +207,7 @@ copy_file(file, parent, name: nil)
 
 thumbnail(file, min_height: nil, min_width: nil, max_height: nil, max_width: nil)
 
-create_shared_link_for_file(file, access: nil, unshared_at: nil, can_download: nil, can_preview: nil)
+create_shared_link_for_file(file, access: nil, unshared_at: nil, password: nil, can_download: nil, can_preview: nil)
 
 disable_shared_link_for_file(file)
 

--- a/lib/boxr/client.rb
+++ b/lib/boxr/client.rb
@@ -286,9 +286,10 @@ module Boxr
       restored_item
     end
 
-    def create_shared_link(uri, item_id, access, unshared_at, can_download, can_preview)
+    def create_shared_link(uri, item_id, access, unshared_at, password, can_download, can_preview)
       attributes = {shared_link: {access: access}}
       attributes[:shared_link][:unshared_at] = unshared_at.to_datetime.rfc3339 unless unshared_at.nil?
+      attributes[:shared_link][:password] = password unless password.nil?
       attributes[:shared_link][:permissions] = {} unless can_download.nil? && can_preview.nil?
       attributes[:shared_link][:permissions][:can_download] = can_download unless can_download.nil?
       attributes[:shared_link][:permissions][:can_preview] = can_preview unless can_preview.nil?

--- a/lib/boxr/files.rb
+++ b/lib/boxr/files.rb
@@ -211,10 +211,10 @@ module Boxr
       thumbnail
     end
 
-    def create_shared_link_for_file(file, access: nil, unshared_at: nil, can_download: nil, can_preview: nil)
+    def create_shared_link_for_file(file, access: nil, unshared_at: nil, password: nil, can_download: nil, can_preview: nil)
       file_id = ensure_id(file)
       uri = "#{FILES_URI}/#{file_id}"
-      create_shared_link(uri, file_id, access, unshared_at, can_download, can_preview)
+      create_shared_link(uri, file_id, access, unshared_at, password, can_download, can_preview)
     end
 
     def disable_shared_link_for_file(file)

--- a/lib/boxr/folders.rb
+++ b/lib/boxr/folders.rb
@@ -103,10 +103,10 @@ module Boxr
       new_folder
     end
 
-    def create_shared_link_for_folder(folder, access: nil, unshared_at: nil, can_download: nil, can_preview: nil)
+    def create_shared_link_for_folder(folder, access: nil, unshared_at: nil, password: nil, can_download: nil, can_preview: nil)
       folder_id = ensure_id(folder)
       uri = "#{FOLDERS_URI}/#{folder_id}"
-      create_shared_link(uri, folder_id, access, unshared_at, can_download, can_preview)
+      create_shared_link(uri, folder_id, access, unshared_at, password, can_download, can_preview)
     end
 
     def disable_shared_link_for_folder(folder)

--- a/spec/boxr_spec.rb
+++ b/spec/boxr_spec.rb
@@ -90,6 +90,10 @@ describe Boxr::Client do
     puts "create shared link for folder"
     updated_folder = BOX_CLIENT.create_shared_link_for_folder(@test_folder, access: :open)
     expect(updated_folder.shared_link.access).to eq("open")
+
+    puts "create password-protected shared link for folder"
+    updated_folder = BOX_CLIENT.create_shared_link_for_folder(@test_folder, password: 'password')
+    expect(updated_folder.shared_link.is_password_enabled).to eq(true)
     shared_link = updated_folder.shared_link.url
 
     puts "inspect shared link"
@@ -210,6 +214,10 @@ describe Boxr::Client do
     puts "create shared link for file"
     updated_file = BOX_CLIENT.create_shared_link_for_file(test_file, access: :open)
     expect(updated_file.shared_link.access).to eq("open")
+
+    puts "create password-protected shared link for file"
+    updated_file = BOX_CLIENT.create_shared_link_for_file(test_file, password: 'password')
+    expect(updated_file.shared_link.is_password_enabled).to eq(true)
 
     puts "disable shared link for file"
     updated_file = BOX_CLIENT.disable_shared_link_for_file(test_file)


### PR DESCRIPTION
The box.com API allows for password-protected [shared links](https://box-content.readme.io/reference#create-a-shared-link-for-a-file) for files and folders by passing a password parameter.
