### PR TITLE
Add ability to move content from one folder to another

### DIFF
--- a/lib/boxr/users.rb
+++ b/lib/boxr/users.rb
@@ -97,6 +97,12 @@ module Boxr
       updated_user
     end
 
+    def move_users_folders(source_id, destination_id)
+      uri = "#{USERS_URI}/#{source_id}/folders/0" #Current API supports only 0(root level folder)
+      folder, response = put(uri, {owned_by: {id: destination_id}})
+      folder
+    end
+
     def delete_user(user, notify: nil, force: nil)
       user_id = ensure_id(user)
       uri = "#{USERS_URI}/#{user_id}"


### PR DESCRIPTION
Added API integration for Move User's Folder (https://box-content.readme.io/reference#move-folder-into-another-users-folder).
