### PR TITLE
Style and syntax cleanup

### DIFF
--- a/bin/boxr
+++ b/bin/boxr
@@ -1,9 +1,10 @@
 #!/usr/bin/env ruby
 
 require 'boxr'
-require 'dotenv'; Dotenv.load
+require 'dotenv'
+Dotenv.load
 require 'awesome_print'
 require 'irb'
 
-$boxr = Boxr::Client.new #uses ENV['BOX_DEVELOPER_TOKEN']
+$boxr = Boxr::Client.new # uses ENV['BOX_DEVELOPER_TOKEN']
 IRB.start

--- a/examples/enterprise_events.rb
+++ b/examples/enterprise_events.rb
@@ -1,24 +1,32 @@
-require 'dotenv'; Dotenv.load("../.env")
+require 'dotenv'
+Dotenv.load('../.env')
 require 'boxr'
 require 'awesome_print'
 
 client = Boxr::Client.new(ENV['BOX_DEVELOPER_TOKEN'])
 
 now = Time.now.utc
-start_date = now - (60*60*24) #one day ago
+start_date = now - (60 * 60 * 24) # one day ago
 
-puts "fetching historic enterprise events..."
+puts 'fetching historic enterprise events...'
 result = client.enterprise_events(created_after: start_date, created_before: now)
 
-ap result.events.each{|event| ap event; puts;}
-output={count: result.events.count, next_stream_position: result.next_stream_position}
+ap result.events.each { |event|
+  ap event
+  puts
+}
+output = { count: result.events.count, next_stream_position: result.next_stream_position }
 ap output
 
-#now that we have the latest stream position let's start monitoring in real-time
-puts "listening for new enterprise events..."
-client.enterprise_events_stream(result.next_stream_position, refresh_period: 5) do |result|
-  result.events.each{|e| ap e}
-  output={count: result.events.count, next_stream_position: result.next_stream_position}
+# now that we have the latest stream position let's start monitoring in
+# real-time
+
+puts 'listening for new enterprise events...'
+client.enterprise_events_stream(result.next_stream_position, refresh_period: 5) do |client_result|
+  client_result.events.each do |e|
+    ap e
+  end
+  output = { count: client_result.events.count, next_stream_position: client_result.next_stream_position }
   ap output
-  puts "waiting..."
+  puts 'waiting...'
 end

--- a/examples/jwt_auth.rb
+++ b/examples/jwt_auth.rb
@@ -1,12 +1,14 @@
-require 'dotenv'; Dotenv.load("../.env")
+require 'dotenv'
+Dotenv.load('../.env')
 require 'boxr'
 require 'awesome_print'
 require 'openssl'
 
-
 private_key = OpenSSL::PKey::RSA.new(File.read(ENV['JWT_PRIVATE_KEY_PATH']), ENV['JWT_PRIVATE_KEY_PASSWORD'])
 
-#make sure ENV['BOX_ENTERPRISE_ID'], ENV['BOX_CLIENT_ID'] and ENV['BOX_CLIENT_SECRET'] are set
-response = Boxr::get_enterprise_token(private_key: private_key)
+# make sure ENV['BOX_ENTERPRISE_ID'], ENV['BOX_CLIENT_ID'] and
+# ENV['BOX_CLIENT_SECRET'] are set
+
+response = Boxr.get_enterprise_token(private_key: private_key)
 
 ap response

--- a/examples/metadata_search.rb
+++ b/examples/metadata_search.rb
@@ -1,19 +1,23 @@
-require 'dotenv'; Dotenv.load("../.env")
+require 'dotenv'
+Dotenv.load('../.env')
 require 'awesome_print'
 require 'boxr'
 
 box_client = Boxr::Client.new(ENV['BOX_DEVELOPER_TOKEN'])
 
 mdfilters = [
-              {
-                "templateKey" => "test1", 
-                "scope" => "enterprise", 
-                "filters" => {
-                  "attrone" => "blah",
-                  "attrtwo" => {"gt" => "4", "lt" => "7"}
-                }
-              }
-            ]
+  {
+    'templateKey' => 'test1',
+    'scope' => 'enterprise',
+    'filters' => {
+      'attrone' => 'blah',
+      'attrtwo' => {
+        'gt' => '4',
+        'lt' => '7'
+      }
+    }
+  }
+]
 
 results = box_client.search(mdfilters: mdfilters)
 ap results

--- a/examples/oauth.rb
+++ b/examples/oauth.rb
@@ -1,27 +1,27 @@
-require 'dotenv'; Dotenv.load("../.env")
+require 'dotenv'
+Dotenv.load('../.env')
 require 'boxr'
 require 'uri'
 require 'awesome_print'
 
-#make sure you have BOX_CLIENT_ID and BOX_CLIENT_SECRET set in your .env file
-#make sure you have the redirect_uri for your application set to something like http://localhost:1234 in the developer portal
+# make sure you have BOX_CLIENT_ID and BOX_CLIENT_SECRET set in your .env file
+# make sure you have the redirect_uri for your application set to something like
+# http://localhost:1234 in the developer portal
 
-oauth_url = Boxr::oauth_url(URI.encode_www_form_component('your-anti-forgery-token'))
+oauth_url = Boxr.oauth_url(URI.encode_www_form_component('your-anti-forgery-token'))
 
-puts "Copy the URL below and paste into a browser. Go through the OAuth flow using the desired Box account. \
-When you are finished your browser will redirect to a 404 error page. This is expected behavior. Look at the URL in the address \
-bar and copy the 'code' parameter value. Paste it into the prompt below. You only have 30 seconds to complete this task so be quick about it! \
+puts "Copy the URL below and paste into a browser. Go through the OAuth flow \
+using the desired Box account. When you are finished your browser will redirect\
+ to a 404 error page. This is expected behavior. Look at the URL in the address\
+ bar and copy the 'code' parameter value. Paste it into the prompt below. You \
+only have 30 seconds to complete this task so be quick about it! \
 You will then see your access token and refresh token."
 
 puts
 puts "URL:  #{oauth_url}"
 puts
 
-print "Enter the code: "
+print 'Enter the code: '
 code = STDIN.gets.chomp.split('=').last
 
-ap Boxr::get_tokens(code)
-
-
-
-
+ap Boxr.get_tokens(code)

--- a/examples/remove_collaborators.rb
+++ b/examples/remove_collaborators.rb
@@ -1,4 +1,5 @@
-require 'dotenv'; Dotenv.load("../.env")
+require 'dotenv'
+Dotenv.load('../.env')
 require 'awesome_print'
 require 'boxr'
 
@@ -6,13 +7,13 @@ box_client = Boxr::Client.new(ENV['BOX_DEVELOPER_TOKEN'])
 
 current_user_id = box_client.me.id
 
-folders = box_client.root_folder_items(fields:[:owned_by, :name]).folders
-owned_folders = folders.select{|f| f.owned_by.id == current_user_id}
+folders = box_client.root_folder_items(fields: [:owned_by, :name]).folders
+owned_folders = folders.select { |f| f.owned_by.id == current_user_id }
 
 removed_count = 0
 owned_folders.each do |f|
   puts "Checking folder '#{f.name}'"
-  collabs = box_client.folder_collaborations(f, fields:[:accessible_by])
+  collabs = box_client.folder_collaborations(f, fields: [:accessible_by])
   collabs.each do |c|
     box_client.remove_collaboration(c)
     removed_count += 1

--- a/examples/use_events_to_send_sms.rb
+++ b/examples/use_events_to_send_sms.rb
@@ -1,59 +1,59 @@
-require 'dotenv'; Dotenv.load("../.env")
+require 'dotenv'
+Dotenv.load('../.env')
 require 'boxr'
-require 'twilio-ruby' #make sure you 'gem install twilio-ruby'
- 
+require 'twilio-ruby' # make sure you 'gem install twilio-ruby'
+
 # Get your Account Sid, Auth Token, and phone number from twilio.com/user/account
-TWILIO_PHONE_NUMBER= ENV['TWILIO_PHONE_NUMBER']
-BOX_TRIGGER_EVENT = 'UPLOAD'
+TWILIO_PHONE_NUMBER = ENV['TWILIO_PHONE_NUMBER']
+BOX_TRIGGER_EVENT = 'UPLOAD'.freeze
 
 @twilio_client = Twilio::REST::Client.new(ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN'])
 @box_client = Boxr::Client.new(ENV['BOX_DEVELOPER_TOKEN'])
 
 def send_sms_to_box_user(recipient, message)
-  begin
-    phone = @box_client.user(recipient, fields: [:phone]).phone
-    unless phone.nil? || phone.empty?
-      begin
-        full_phone = "+1#{phone}"
-        @twilio_client.account.messages.create(
-          from: ENV['TWILIO_PHONE_NUMBER'],
-          to: full_phone,
-          body: message
-        )
-        puts "Sent SMS to user #{recipient.name} at #{full_phone}"
-      rescue Twilio::REST::RequestError => e
-        puts e.message
-      end
+  phone = @box_client.user(recipient, fields: [:phone]).phone
+  unless phone.nil? || phone.empty?
+    begin
+      full_phone = "+1#{phone}"
+      @twilio_client.account.messages.create(
+        from: ENV['TWILIO_PHONE_NUMBER'],
+        to: full_phone,
+        body: message
+      )
+      puts "Sent SMS to user #{recipient.name} at #{full_phone}"
+    rescue Twilio::REST::RequestError => e
+      puts e.message
     end
-  rescue Boxr::BoxrError => e
-    #most likely error is that a collaborator is an external user and Box threw a 404
-    puts e.message
   end
+rescue Boxr::BoxrError => e
+  # most likely error is that a collaborator is an external user and Box threw
+  # a 404
+  puts e.message
 end
 
-#need to look back in time to make sure we get a valid stream position; 
-#normally your app will be persisting the last known stream position and you wouldn't have to look this up
+# need to look back in time to make sure we get a valid stream position;
+# normally your app will be persisting the last known stream position and you
+# wouldn't have to look this up
 now = Time.now.utc
-start_date = now - (60*60*24) #one day ago
+start_date = now - (60 * 60 * 24) # one day ago
 result = @box_client.enterprise_events(created_after: start_date, created_before: now)
 
-#now that we have the latest stream position let's start monitoring in real-time
+# now that we have the latest stream position let's start monitoring in real-time
 @box_client.enterprise_events_stream(result.next_stream_position, event_type: BOX_TRIGGER_EVENT, refresh_period: 5) do |result|
-  if result.events.count==0
+  if result.events.count == 0
     puts "no new #{BOX_TRIGGER_EVENT} events..."
   else
     puts "detected #{result.events.count} new #{BOX_TRIGGER_EVENT}"
     result.events.each do |e|
       folder = @box_client.folder(e.source.parent)
       message = "Document '#{e.source.item_name}' uploaded to folder '#{folder.name}' by #{e.created_by.name}"
-      
-      #first notify the folder owner
+
+      # first notify the folder owner
       send_sms_to_box_user(folder.owned_by, message)
 
-      #now notify collaborators
-      user_collabs = @box_client.folder_collaborations(folder).select{|c| c.accessible_by.type=='user'}
-      user_collabs.each{|c| send_sms_to_box_user(c.accessible_by, message)}
+      # now notify collaborators
+      user_collabs = @box_client.folder_collaborations(folder).select { |c| c.accessible_by.type == 'user' }
+      user_collabs.each { |c| send_sms_to_box_user(c.accessible_by, message) }
     end
   end
 end
-

--- a/examples/use_events_to_warn_about_sharing.rb
+++ b/examples/use_events_to_warn_about_sharing.rb
@@ -1,92 +1,95 @@
-require 'dotenv'; Dotenv.load("../.env")
+require 'dotenv'
+Dotenv.load('../.env')
 require 'boxr'
-require 'mailgun' #make sure you 'gem install mailgun-ruby'
- 
-BOX_TRIGGER_EVENT = 'ITEM_SHARED_UPDATE,COLLABORATION_INVITE'
-FROM_EMAIL = "box-admin@#{ENV['MAILGUN_SENDING_DOMAIN']}"
-VALID_COLLABORATION_DOMAIN=ENV['VALID_COLLABORATION_DOMAIN'] #i.e. 'your-company.com'
+require 'mailgun' # make sure you 'gem install mailgun-ruby'
+
+BOX_TRIGGER_EVENT = 'ITEM_SHARED_UPDATE,COLLABORATION_INVITE'.freeze
+FROM_EMAIL = "box-admin@#{ENV['MAILGUN_SENDING_DOMAIN']}".freeze
+VALID_COLLABORATION_DOMAIN = ENV['VALID_COLLABORATION_DOMAIN'] # i.e. 'your-company.com'
 
 @mailgun_client = Mailgun::Client.new ENV['MAILGUN_API_KEY']
 @box_client = Boxr::Client.new(ENV['BOX_DEVELOPER_TOKEN'])
 
 def file_warning_text(event)
-%(
-Our records indicate that you just created an open shared link for the document '#{event.source.item_name}'
-located in the folder '#{event.source.parent.name}'. 
+  %(
+  Our records indicate that you just created an open shared link for the document '#{event.source.item_name}'
+  located in the folder '#{event.source.parent.name}'.
 
-If you meant to do this, please ignore this email.  Otherwise, please update this shared link
-so that it is no longer open access.
+  If you meant to do this, please ignore this email.  Otherwise, please update this shared link
+  so that it is no longer open access.
 
-Thanks,
-Your Box Admin
-)
+  Thanks,
+  Your Box Admin
+  )
 end
 
 def folder_warning_text(event)
-%(
-Our records indicate that you just created an open shared link for the folder '#{event.source.item_name}'. 
+  %(
+  Our records indicate that you just created an open shared link for the folder '#{event.source.item_name}'.
 
-If you meant to do this, please ignore this email.  Otherwise, please update this shared link
-so that it is no longer open access.
+  If you meant to do this, please ignore this email.  Otherwise, please update this shared link
+  so that it is no longer open access.
 
-Thanks,
-Your Box Admin
-)
+  Thanks,
+  Your Box Admin
+  )
 end
 
 def collaboration_warning_text(event)
-%(
-Our records indicate that you just invited #{event.accessible_by.login} to be an external collaborator
-with the role of #{event.additional_details.role} in the folder '#{event.source.folder_name}'. 
+  %(
+  Our records indicate that you just invited #{event.accessible_by.login} to be an external collaborator
+  with the role of #{event.additional_details.role} in the folder '#{event.source.folder_name}'.
 
-If you meant to do this, please ignore this email.  Otherwise, please remove this collaborator.
+  If you meant to do this, please ignore this email.  Otherwise, please remove this collaborator.
 
-Thanks,
-Your Box Admin
-)
+  Thanks,
+  Your Box Admin
+  )
 end
 
 def send_email_to_box_user(from, to, subject, text)
-  #this example code uses Mailgun to send email, but you can use any standard SMTP server
-  message_params = {:from => from, :to => to, :subject => subject, :text => text}
+  # this example code uses Mailgun to send email, but you can use any standard
+  # SMTP server
+  message_params = { from: from, to: to, subject: subject, text: text }
   @mailgun_client.send_message ENV['MAILGUN_SENDING_DOMAIN'], message_params
 
   puts "Sent email to #{to} with subject '#{subject}'"
 end
 
-#need to look back in time to make sure we get a valid stream position; 
-#normally your app will be persisting the last known stream position and you wouldn't have to look this up
+# need to look back in time to make sure we get a valid stream position;
+# normally your app will be persisting the last known stream position and you
+# wouldn't have to look this up
 now = Time.now.utc
-start_date = now - (60*60*24) #one day ago
+start_date = now - (60 * 60 * 24) # one day ago
 result = @box_client.enterprise_events(created_after: start_date, created_before: now)
 
-#now that we have the latest stream position let's start monitoring in real-time
-@box_client.enterprise_events_stream(result.next_stream_position, event_type: BOX_TRIGGER_EVENT, refresh_period: 60) do |result|
-  if result.events.count==0
+# now that we have the latest stream position let's start monitoring in
+# real-time
+@box_client.enterprise_events_stream(result.next_stream_position, event_type: BOX_TRIGGER_EVENT, refresh_period: 60) do |client_result|
+  if client_result.events.count == 0
     puts "no new #{BOX_TRIGGER_EVENT} events..."
   else
-    result.events.each do |e|
+    client_result.events.each do |e|
       puts "detected new #{e.event_type}"
-      if e.event_type=='ITEM_SHARED_UPDATE'
-        if e.source.item_type=='file'
+      if e.event_type == 'ITEM_SHARED_UPDATE'
+        if e.source.item_type == 'file'
           file = @box_client.file(e.source.item_id)
-          if file.shared_link.effective_access=='open'
-            send_email_to_box_user(FROM_EMAIL, e.created_by.login, "WARNING: Open Shared Link Detected", file_warning_text(e))
+          if file.shared_link.effective_access == 'open'
+            send_email_to_box_user(FROM_EMAIL, e.created_by.login, 'WARNING: Open Shared Link Detected', file_warning_text(e))
           end
-        elsif e.source.item_type=='folder'
+        elsif e.source.item_type == 'folder'
           folder = @box_client.folder(e.source.item_id)
-          if folder.shared_link.effective_access=='open'
-            send_email_to_box_user(FROM_EMAIL, e.created_by.login, "WARNING: Open Shared Link Detected", folder_warning_text(e))
+          if folder.shared_link.effective_access == 'open'
+            send_email_to_box_user(FROM_EMAIL, e.created_by.login, 'WARNING: Open Shared Link Detected', folder_warning_text(e))
           end
         end
-      elsif e.event_type=='COLLABORATION_INVITE'
+      elsif e.event_type == 'COLLABORATION_INVITE'
         email = e.accessible_by.login
         domain = email.split('@').last
-        unless domain.downcase==VALID_COLLABORATION_DOMAIN.downcase
-          send_email_to_box_user(FROM_EMAIL, e.created_by.login, "WARNING: External Collaborator Detected", collaboration_warning_text(e))
+        unless domain.casecmp(VALID_COLLABORATION_DOMAIN.downcase).zero?
+          send_email_to_box_user(FROM_EMAIL, e.created_by.login, 'WARNING: External Collaborator Detected', collaboration_warning_text(e))
         end
       end
     end
   end
 end
-

--- a/examples/user_events.rb
+++ b/examples/user_events.rb
@@ -1,4 +1,5 @@
-require 'dotenv'; Dotenv.load("../.env")
+require 'dotenv'
+Dotenv.load('../.env')
 require 'boxr'
 require 'awesome_print'
 require 'lru_redux'
@@ -7,13 +8,14 @@ client = Boxr::Client.new(ENV['BOX_DEVELOPER_TOKEN'])
 cache = LruRedux::Cache.new(1000)
 
 stream_position = :now
-loop do 
-  puts "fetching events..."
+loop do
+  puts 'fetching events...'
   event_response = client.user_events(stream_position)
   event_response.events.each do |event|
-    #we need to de-dupe the events because we will receive multiple events with the same event_id; Box does this to ensure that we get the event
+    # we need to de-dupe the events because we will receive multiple events with
+    # the same event_id; Box does this to ensure that we get the event
     key = "/box-event/#{event.event_id}"
-    if (cache.fetch(key)==nil)
+    if cache.fetch(key).nil?
       cache[key] = true
       puts event.event_type
     end

--- a/lib/boxr.rb
+++ b/lib/boxr.rb
@@ -25,44 +25,44 @@ require 'boxr/web_links'
 
 module Enumerable
   def files
-    self.select{|i| i.type == 'file'}
+    select { |i| i.type == 'file' }
   end
 
   def folders
-    self.select{|i| i.type == 'folder'}
+    select { |i| i.type == 'folder' }
   end
 
   def web_links
-    self.select{|i| i.type == 'web_link'}
+    select { |i| i.type == 'web_link' }
   end
 end
 
 class BoxrMash < Hashie::Mash
   def entries
-    self["entries"]
+    self['entries']
   end
 
   def size
-    self["size"]
+    self['size']
   end
 end
 
 module Boxr
-  Oj.default_options = {:mode => :compat }
+  Oj.default_options = { mode: :compat }
 
-  #The root folder in Box is always identified by 0
+  # The root folder in Box is always identified by 0
   ROOT = 0
 
-  #HTTPClient is high-performance, thread-safe, and supports persistent HTTPS connections
-  #http://bibwild.wordpress.com/2012/04/30/ruby-http-performance-shootout-redux/
+  # HTTPClient is high-performance, thread-safe, and supports persistent HTTPS connections
+  # http://bibwild.wordpress.com/2012/04/30/ruby-http-performance-shootout-redux/
   BOX_CLIENT = HTTPClient.new
   BOX_CLIENT.cookie_manager = nil
-  BOX_CLIENT.send_timeout = 3600 #one hour; needed for lengthy uploads
+  BOX_CLIENT.send_timeout = 3600 # one hour; needed for lengthy uploads
   BOX_CLIENT.agent_name = "Boxr/#{Boxr::VERSION}"
   BOX_CLIENT.transparent_gzip_decompression = true
-  #BOX_CLIENT.ssl_config.add_trust_ca("/Users/cburnette/code/ssh-keys/dev_root_ca.pem")
+  # BOX_CLIENT.ssl_config.add_trust_ca("/Users/cburnette/code/ssh-keys/dev_root_ca.pem")
 
-  def self.turn_on_debugging(device=STDOUT)
+  def self.turn_on_debugging(device = STDOUT)
     BOX_CLIENT.debug_dev = device
     BOX_CLIENT.transparent_gzip_decompression = false
     nil

--- a/lib/boxr/auth.rb
+++ b/lib/boxr/auth.rb
@@ -1,102 +1,99 @@
 module Boxr
+  JWT_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'.freeze
 
-  JWT_GRANT_TYPE="urn:ietf:params:oauth:grant-type:jwt-bearer"
+  def self.oauth_url(state, host: 'app.box.com', response_type: 'code', scope: nil, folder_id: nil, client_id: ENV['BOX_CLIENT_ID'])
+    template = Addressable::Template.new('https://{host}/api/oauth2/authorize{?query*}')
 
-  def self.oauth_url(state, host: "app.box.com", response_type: "code", scope: nil, folder_id: nil, client_id: ENV['BOX_CLIENT_ID'])
-    template = Addressable::Template.new("https://{host}/api/oauth2/authorize{?query*}")
+    query = { 'response_type' => response_type.to_s, 'state' => state.to_s, 'client_id' => client_id.to_s }
+    query['scope'] = scope.to_s unless scope.nil?
+    query['folder_id'] = folder_id.to_s unless folder_id.nil?
 
-    query = {"response_type" => "#{response_type}", "state" => "#{state}", "client_id" => "#{client_id}"}
-    query["scope"] = "#{scope}" unless scope.nil?
-    query["folder_id"] = "#{folder_id}" unless folder_id.nil?
-    
-    uri = template.expand({"host" => "#{host}", "query" => query})
+    uri = template.expand('host' => host.to_s, 'query' => query)
     uri
   end
 
-  def self.get_tokens(code=nil, grant_type: "authorization_code", assertion: nil, scope: nil, username: nil, client_id: ENV['BOX_CLIENT_ID'], client_secret: ENV['BOX_CLIENT_SECRET'])
-    uri = "https://api.box.com/oauth2/token"
+  def self.get_tokens(code = nil, grant_type: 'authorization_code', assertion: nil, scope: nil, username: nil, client_id: ENV['BOX_CLIENT_ID'], client_secret: ENV['BOX_CLIENT_SECRET'])
+    uri = 'https://api.box.com/oauth2/token'
     body = "grant_type=#{grant_type}&client_id=#{client_id}&client_secret=#{client_secret}"
-    body = body + "&code=#{code}" unless code.nil?
-    body = body + "&scope=#{scope}" unless scope.nil?
-    body = body + "&username=#{username}" unless username.nil?
-    body = body + "&assertion=#{assertion}" unless assertion.nil?
+    body += "&code=#{code}" unless code.nil?
+    body += "&scope=#{scope}" unless scope.nil?
+    body += "&username=#{username}" unless username.nil?
+    body += "&assertion=#{assertion}" unless assertion.nil?
 
     auth_post(uri, body)
   end
 
   def self.get_enterprise_token(private_key: ENV['JWT_PRIVATE_KEY'], private_key_password: ENV['JWT_PRIVATE_KEY_PASSWORD'],
-                                public_key_id: ENV['JWT_PUBLIC_KEY_ID'], enterprise_id: ENV['BOX_ENTERPRISE_ID'], 
+                                public_key_id: ENV['JWT_PUBLIC_KEY_ID'], enterprise_id: ENV['BOX_ENTERPRISE_ID'],
                                 client_id: ENV['BOX_CLIENT_ID'], client_secret: ENV['BOX_CLIENT_SECRET'])
     unlocked_private_key = unlock_key(private_key, private_key_password)
-    assertion = jwt_assertion(unlocked_private_key, client_id, enterprise_id, "enterprise", public_key_id)
+    assertion = jwt_assertion(unlocked_private_key, client_id, enterprise_id, 'enterprise', public_key_id)
     get_token(grant_type: JWT_GRANT_TYPE, assertion: assertion, client_id: client_id, client_secret: client_secret)
   end
 
   def self.get_user_token(user_id, private_key: ENV['JWT_PRIVATE_KEY'], private_key_password: ENV['JWT_PRIVATE_KEY_PASSWORD'],
                           public_key_id: ENV['JWT_PUBLIC_KEY_ID'], client_id: ENV['BOX_CLIENT_ID'], client_secret: ENV['BOX_CLIENT_SECRET'])
     unlocked_private_key = unlock_key(private_key, private_key_password)
-    assertion = jwt_assertion(unlocked_private_key, client_id, user_id, "user", public_key_id)
+    assertion = jwt_assertion(unlocked_private_key, client_id, user_id, 'user', public_key_id)
     get_token(grant_type: JWT_GRANT_TYPE, assertion: assertion, client_id: client_id, client_secret: client_secret)
   end
 
   def self.refresh_tokens(refresh_token, client_id: ENV['BOX_CLIENT_ID'], client_secret: ENV['BOX_CLIENT_SECRET'])
-    uri = "https://api.box.com/oauth2/token"
+    uri = 'https://api.box.com/oauth2/token'
     body = "grant_type=refresh_token&refresh_token=#{refresh_token}&client_id=#{client_id}&client_secret=#{client_secret}"
 
     auth_post(uri, body)
   end
 
   def self.revoke_tokens(token, client_id: ENV['BOX_CLIENT_ID'], client_secret: ENV['BOX_CLIENT_SECRET'])
-    uri = "https://api.box.com/oauth2/revoke"
+    uri = 'https://api.box.com/oauth2/revoke'
     body = "client_id=#{client_id}&client_secret=#{client_secret}&token=#{token}"
 
     auth_post(uri, body)
   end
 
   class << self
-    alias :get_token :get_tokens
-    alias :refresh_token :refresh_tokens
-    alias :revoke_token :revoke_tokens
-  end
+    alias get_token get_tokens
+    alias refresh_token refresh_tokens
+    alias revoke_token revoke_tokens
 
-  private
+    private
 
+    def self.jwt_assertion(private_key, iss, sub, box_sub_type, public_key_id)
+      payload = {
+        iss: iss,
+        sub: sub,
+        box_sub_type: box_sub_type,
+        aud: 'https://api.box.com/oauth2/token',
+        jti: SecureRandom.hex(64),
+        exp: (Time.now.utc + 10).to_i
+      }
 
-  def self.jwt_assertion(private_key, iss, sub, box_sub_type, public_key_id)
-    payload = {
-      iss: iss,
-      sub: sub,
-      box_sub_type: box_sub_type,
-      aud: "https://api.box.com/oauth2/token",
-      jti: SecureRandom.hex(64),
-      exp: (Time.now.utc + 10).to_i
-    }
+      additional_headers = {}
+      additional_headers['kid'] = public_key_id unless public_key_id.nil?
 
-    additional_headers = {}
-    additional_headers['kid'] = public_key_id unless public_key_id.nil?
-    
-    JWT.encode(payload, private_key, "RS256", additional_headers)
-  end
+      JWT.encode(payload, private_key, 'RS256', additional_headers)
+    end
 
-  def self.auth_post(uri, body)
-    uri = Addressable::URI.encode(uri)
+    def self.auth_post(uri, body)
+      uri = Addressable::URI.encode(uri)
 
-    res = BOX_CLIENT.post(uri, body: body)
+      res = BOX_CLIENT.post(uri, body: body)
 
-    if(res.status==200)
-      body_json = Oj.load(res.body)
-      return BoxrMash.new(body_json)
-    else
-      raise BoxrError.new(status: res.status, body: res.body, header: res.header)
+      if res.status == 200
+        body_json = Oj.load(res.body)
+        return BoxrMash.new(body_json)
+      else
+        raise BoxrError.new(status: res.status, body: res.body, header: res.header)
+      end
+    end
+
+    def self.unlock_key(private_key, private_key_password)
+      if private_key.is_a?(OpenSSL::PKey::RSA)
+        private_key
+      else
+        OpenSSL::PKey::RSA.new(private_key, private_key_password)
+      end
     end
   end
-
-  def self.unlock_key(private_key, private_key_password)
-    if private_key.is_a?(OpenSSL::PKey::RSA)
-      private_key
-    else
-      OpenSSL::PKey::RSA.new(private_key, private_key_password)
-    end
-  end
-
 end

--- a/lib/boxr/client.rb
+++ b/lib/boxr/client.rb
@@ -1,79 +1,75 @@
 module Boxr
-
   class Client
-
     attr_reader :access_token, :refresh_token, :client_id, :client_secret, :identifier, :as_user_id
 
-    #API_URI = "https://wcheng.inside-box.net/api/2.0"
-    #UPLOAD_URI = "https://upload.wcheng.inside-box.net/api/2.0"
+    # API_URI = "https://wcheng.inside-box.net/api/2.0"
+    # UPLOAD_URI = "https://upload.wcheng.inside-box.net/api/2.0"
 
-    API_URI = "https://api.box.com/2.0"
-    UPLOAD_URI = "https://upload.box.com/api/2.0"
-    FILES_URI = "#{API_URI}/files"
-    FILES_UPLOAD_URI = "#{UPLOAD_URI}/files/content"
-    FOLDERS_URI = "#{API_URI}/folders"
-    USERS_URI = "#{API_URI}/users"
-    GROUPS_URI = "#{API_URI}/groups"
-    GROUP_MEMBERSHIPS_URI = "#{API_URI}/group_memberships"
-    COLLABORATIONS_URI = "#{API_URI}/collaborations"
-    COLLECTIONS_URI = "#{API_URI}/collections"
-    COMMENTS_URI = "#{API_URI}/comments"
-    SEARCH_URI = "#{API_URI}/search"
-    TASKS_URI = "#{API_URI}/tasks"
-    TASK_ASSIGNMENTS_URI = "#{API_URI}/task_assignments"
-    SHARED_ITEMS_URI = "#{API_URI}/shared_items"
-    FILE_METADATA_URI = "#{API_URI}/files"
-    FOLDER_METADATA_URI = "#{API_URI}/folders"
-    METADATA_TEMPLATES_URI = "#{API_URI}/metadata_templates"
-    EVENTS_URI = "#{API_URI}/events"
-    WEB_LINKS_URI = "#{API_URI}/web_links"
-
+    API_URI = 'https://api.box.com/2.0'.freeze
+    UPLOAD_URI = 'https://upload.box.com/api/2.0'.freeze
+    FILES_URI = "#{API_URI}/files".freeze
+    FILES_UPLOAD_URI = "#{UPLOAD_URI}/files/content".freeze
+    FOLDERS_URI = "#{API_URI}/folders".freeze
+    USERS_URI = "#{API_URI}/users".freeze
+    GROUPS_URI = "#{API_URI}/groups".freeze
+    GROUP_MEMBERSHIPS_URI = "#{API_URI}/group_memberships".freeze
+    COLLABORATIONS_URI = "#{API_URI}/collaborations".freeze
+    COLLECTIONS_URI = "#{API_URI}/collections".freeze
+    COMMENTS_URI = "#{API_URI}/comments".freeze
+    SEARCH_URI = "#{API_URI}/search".freeze
+    TASKS_URI = "#{API_URI}/tasks".freeze
+    TASK_ASSIGNMENTS_URI = "#{API_URI}/task_assignments".freeze
+    SHARED_ITEMS_URI = "#{API_URI}/shared_items".freeze
+    FILE_METADATA_URI = "#{API_URI}/files".freeze
+    FOLDER_METADATA_URI = "#{API_URI}/folders".freeze
+    METADATA_TEMPLATES_URI = "#{API_URI}/metadata_templates".freeze
+    EVENTS_URI = "#{API_URI}/events".freeze
+    WEB_LINKS_URI = "#{API_URI}/web_links".freeze
 
     DEFAULT_LIMIT = 100
     FOLDER_ITEMS_LIMIT = 1000
 
-    FOLDER_AND_FILE_FIELDS = [:type,:id,:sequence_id,:etag,:name,:created_at,:modified_at,:description,
-                              :size,:path_collection,:created_by,:modified_by,:trashed_at,:purged_at,
-                              :content_created_at,:content_modified_at,:owned_by,:shared_link,:folder_upload_email,
-                              :parent,:item_status,:item_collection,:sync_state,:has_collaborations,:permissions,:tags,
-                              :sha1,:shared_link,:version_number,:comment_count,:lock,:extension,:is_package,:can_non_owners_invite]
+    FOLDER_AND_FILE_FIELDS = [:type, :id, :sequence_id, :etag, :name, :created_at, :modified_at, :description,
+                              :size, :path_collection, :created_by, :modified_by, :trashed_at, :purged_at,
+                              :content_created_at, :content_modified_at, :owned_by, :shared_link, :folder_upload_email,
+                              :parent, :item_status, :item_collection, :sync_state, :has_collaborations, :permissions, :tags,
+                              :sha1, :shared_link, :version_number, :comment_count, :lock, :extension, :is_package, :can_non_owners_invite].freeze
     FOLDER_AND_FILE_FIELDS_QUERY = FOLDER_AND_FILE_FIELDS.join(',')
 
-    COMMENT_FIELDS = [:type,:id,:is_reply_comment,:message,:tagged_message,:created_by,:created_at,:item,:modified_at]
+    COMMENT_FIELDS = [:type, :id, :is_reply_comment, :message, :tagged_message, :created_by, :created_at, :item, :modified_at].freeze
     COMMENT_FIELDS_QUERY = COMMENT_FIELDS.join(',')
 
-    TASK_FIELDS = [:type,:id,:item,:due_at,:action,:message,:task_assignment_collection,:is_completed,:created_by,:created_at]
+    TASK_FIELDS = [:type, :id, :item, :due_at, :action, :message, :task_assignment_collection, :is_completed, :created_by, :created_at].freeze
     TASK_FIELDS_QUERY = TASK_FIELDS.join(',')
 
-    COLLABORATION_FIELDS = [:type,:id,:created_by,:created_at,:modified_at,:expires_at,:status,:accessible_by,:role,:acknowledged_at,:item]
+    COLLABORATION_FIELDS = [:type, :id, :created_by, :created_at, :modified_at, :expires_at, :status, :accessible_by, :role, :acknowledged_at, :item].freeze
     COLLABORATION_FIELDS_QUERY = COLLABORATION_FIELDS.join(',')
 
-    USER_FIELDS = [:type,:id,:name,:login,:created_at,:modified_at,:role,:language,:timezone,:space_amount,:space_used,
-                   :max_upload_size,:tracking_codes,:can_see_managed_users,:is_sync_enabled,:is_external_collab_restricted,
-                   :status,:job_title,:phone,:address,:avatar_uri,:is_exempt_from_device_limits,:is_exempt_from_login_verification,
-                   :enterprise,:my_tags]
+    USER_FIELDS = [:type, :id, :name, :login, :created_at, :modified_at, :role, :language, :timezone, :space_amount, :space_used,
+                   :max_upload_size, :tracking_codes, :can_see_managed_users, :is_sync_enabled, :is_external_collab_restricted,
+                   :status, :job_title, :phone, :address, :avatar_uri, :is_exempt_from_device_limits, :is_exempt_from_login_verification,
+                   :enterprise, :my_tags].freeze
     USER_FIELDS_QUERY = USER_FIELDS.join(',')
 
-    GROUP_FIELDS = [:type, :id, :name, :created_at, :modified_at]
+    GROUP_FIELDS = [:type, :id, :name, :created_at, :modified_at].freeze
     GROUP_FIELDS_QUERY = GROUP_FIELDS.join(',')
 
-    VALID_COLLABORATION_ROLES = ['editor','viewer','previewer','uploader','previewer uploader','viewer uploader','co-owner','owner']
+    VALID_COLLABORATION_ROLES = ['editor', 'viewer', 'previewer', 'uploader', 'previewer uploader', 'viewer uploader', 'co-owner', 'owner'].freeze
 
-
-    def initialize( access_token=ENV['BOX_DEVELOPER_TOKEN'],
-                    refresh_token: nil,
-                    client_id: ENV['BOX_CLIENT_ID'],
-                    client_secret: ENV['BOX_CLIENT_SECRET'],
-                    enterprise_id: ENV['BOX_ENTERPRISE_ID'],
-                    jwt_private_key: ENV['JWT_PRIVATE_KEY'],
-                    jwt_private_key_password: ENV['JWT_PRIVATE_KEY_PASSWORD'],
-                    jwt_public_key_id: ENV['JWT_PUBLIC_KEY_ID'],
-                    identifier: nil,
-                    as_user: nil,
-                    &token_refresh_listener)
+    def initialize(access_token = ENV['BOX_DEVELOPER_TOKEN'],
+                   refresh_token: nil,
+                   client_id: ENV['BOX_CLIENT_ID'],
+                   client_secret: ENV['BOX_CLIENT_SECRET'],
+                   enterprise_id: ENV['BOX_ENTERPRISE_ID'],
+                   jwt_private_key: ENV['JWT_PRIVATE_KEY'],
+                   jwt_private_key_password: ENV['JWT_PRIVATE_KEY_PASSWORD'],
+                   jwt_public_key_id: ENV['JWT_PUBLIC_KEY_ID'],
+                   identifier: nil,
+                   as_user: nil,
+                   &token_refresh_listener)
 
       @access_token = access_token
-      raise BoxrError.new(boxr_message: "Access token cannot be nil") if @access_token.nil?
+      raise BoxrError.new(boxr_message: 'Access token cannot be nil') if @access_token.nil?
 
       @refresh_token = refresh_token
       @client_id = client_id
@@ -86,7 +82,6 @@ module Boxr
       @as_user_id = ensure_id(as_user)
       @token_refresh_listener = token_refresh_listener
     end
-
 
     private
 
@@ -103,11 +98,8 @@ module Boxr
 
       check_response_status(res, success_codes)
 
-      if process_response
-        return processed_response(res)
-      else
-        return res.body, res
-      end
+      return res.body, res unless process_response
+      processed_response(res)
     end
 
     def get_all_with_pagination(uri, query: {}, offset: 0, limit: DEFAULT_LIMIT, follow_redirect: true)
@@ -122,18 +114,18 @@ module Boxr
           BOX_CLIENT.get(uri, query: query, header: headers, follow_redirect: follow_redirect)
         end
 
-        if (res.status==200)
+        if res.status == 200
           body_json = Oj.load(res.body)
-          total_count = body_json["total_count"]
-          offset = offset + limit
+          total_count = body_json['total_count']
+          offset += limit
 
-          entries << body_json["entries"]
+          entries << body_json['entries']
         else
           raise BoxrError.new(status: res.status, body: res.body, header: res.header)
         end
       end until offset - total_count >= 0
 
-      entries.flatten.map{|i| BoxrMash.new(i)}
+      entries.flatten.map { |i| BoxrMash.new(i) }
     end
 
     def post(uri, body, query: nil, success_codes: [201], process_body: true, content_md5: nil, content_type: nil, if_match: nil)
@@ -143,8 +135,8 @@ module Boxr
       res = with_auto_token_refresh do
         headers = standard_headers
         headers['If-Match'] = if_match unless if_match.nil?
-        headers["Content-MD5"] = content_md5 unless content_md5.nil?
-        headers["Content-Type"] = content_type unless content_type.nil?
+        headers['Content-MD5'] = content_md5 unless content_md5.nil?
+        headers['Content-Type'] = content_type unless content_type.nil?
 
         BOX_CLIENT.post(uri, body: body, query: query, header: headers)
       end
@@ -160,7 +152,7 @@ module Boxr
       res = with_auto_token_refresh do
         headers = standard_headers
         headers['If-Match'] = if_match unless if_match.nil?
-        headers["Content-Type"] = content_type unless content_type.nil?
+        headers['Content-Type'] = content_type unless content_type.nil?
 
         BOX_CLIENT.put(uri, body: Oj.dump(body), query: query, header: headers)
       end
@@ -198,35 +190,32 @@ module Boxr
       processed_response(res)
     end
 
-    def standard_headers()
-      headers = {"Authorization" => "Bearer #{@access_token}"}
+    def standard_headers
+      headers = { 'Authorization' => "Bearer #{@access_token}" }
       if @jwt_private_key.nil?
-        headers['As-User'] = "#{@as_user_id}" unless @as_user_id.nil?
+        headers['As-User'] = @as_user_id.to_s unless @as_user_id.nil?
       end
       headers
     end
 
     def with_auto_token_refresh
-      return yield unless @refresh_token or @jwt_secret_key
+      return yield unless @refresh_token || @jwt_secret_key
 
       res = yield
       if res.status == 401
         auth_header = res.header['WWW-Authenticate'][0]
         if auth_header && auth_header.include?('invalid_token')
           if @refresh_token
-            new_tokens = Boxr::refresh_tokens(@refresh_token, client_id: client_id, client_secret: client_secret)
+            new_tokens = Boxr.refresh_tokens(@refresh_token, client_id: client_id, client_secret: client_secret)
             @access_token = new_tokens.access_token
             @refresh_token = new_tokens.refresh_token
             @token_refresh_listener.call(@access_token, @refresh_token, @identifier) if @token_refresh_listener
+          elsif @as_user_id
+            new_token = Boxr.get_user_token(@as_user_id, private_key: @jwt_private_key, private_key_password: @jwt_private_key_password, public_key_id: @jwt_public_key_id, client_id: @client_id, client_secret: @client_secret)
           else
-            if @as_user_id
-              new_token = Boxr::get_user_token(@as_user_id, private_key: @jwt_private_key, private_key_password: @jwt_private_key_password, public_key_id: @jwt_public_key_id, client_id: @client_id, client_secret: @client_secret)
-              @access_token = new_token.access_token
-            else
-              new_token = Boxr::get_enterprise_token(private_key: @jwt_private_key, private_key_password: @jwt_private_key_password, public_key_id: @jwt_public_key_id, enterprise_id: @enterprise_id, client_id: @client_id, client_secret: @client_secret)
-              @access_token = new_token.access_token
-            end
+            new_token = Boxr.get_enterprise_token(private_key: @jwt_private_key, private_key_password: @jwt_private_key_password, public_key_id: @jwt_public_key_id, enterprise_id: @enterprise_id, client_id: @client_id, client_secret: @client_secret)
           end
+          @access_token = new_token.access_token
 
           res = yield
         end
@@ -241,14 +230,14 @@ module Boxr
 
     def processed_response(res)
       body_json = Oj.load(res.body)
-      return BoxrMash.new(body_json), res
+      [BoxrMash.new(body_json), res]
     end
 
     def build_fields_query(fields, all_fields_query)
       if fields == :all
-        {:fields => all_fields_query}
-      elsif fields.is_a?(Array) && fields.length > 0
-        {:fields => fields.join(',')}
+        { fields: all_fields_query }
+      elsif fields.is_a?(Array) && !fields.empty?
+        { fields: fields.join(',') }
       else
         {}
       end
@@ -257,23 +246,19 @@ module Boxr
     def to_comma_separated_string(values)
       return values if values.is_a?(String) || values.is_a?(Symbol)
 
-      if values.is_a?(Array) && values.length > 0
-        values.join(',')
-      else
-        nil
-      end
+      values.join(',') if values.is_a?(Array) && !values.empty?
     end
 
     def build_range_string(from, to)
       range_string = "#{from},#{to}"
-      range_string = nil if range_string == ","
+      range_string = nil if range_string == ','
       range_string
     end
 
     def ensure_id(item)
       return item if item.class == String || item.class == Fixnum || item.nil?
       return item.id if item.respond_to?(:id)
-      raise BoxrError.new(boxr_message: "Expecting an id of class String or Fixnum, or object that responds to :id")
+      raise BoxrError.new(boxr_message: 'Expecting an id of class String or Fixnum, or object that responds to :id')
     end
 
     def restore_trashed_item(uri, name, parent)
@@ -281,30 +266,28 @@ module Boxr
 
       attributes = {}
       attributes[:name] = name unless name.nil?
-      attributes[:parent] = {id: parent_id} unless parent_id.nil?
+      attributes[:parent] = { id: parent_id } unless parent_id.nil?
 
-      restored_item, response = post(uri, attributes)
+      restored_item, _response = post(uri, attributes)
       restored_item
     end
 
-    def create_shared_link(uri, item_id, access, unshared_at, can_download, can_preview)
-      attributes = {shared_link: {access: access}}
+    def create_shared_link(uri, _item_id, access, unshared_at, can_download, can_preview)
+      attributes = { shared_link: { access: access } }
       attributes[:shared_link][:unshared_at] = unshared_at.to_datetime.rfc3339 unless unshared_at.nil?
       attributes[:shared_link][:permissions] = {} unless can_download.nil? && can_preview.nil?
       attributes[:shared_link][:permissions][:can_download] = can_download unless can_download.nil?
       attributes[:shared_link][:permissions][:can_preview] = can_preview unless can_preview.nil?
 
-      updated_item, response = put(uri, attributes)
+      updated_item, _response = put(uri, attributes)
       updated_item
     end
 
     def disable_shared_link(uri)
-      attributes = {shared_link: nil}
+      attributes = { shared_link: nil }
 
-      updated_item, response = put(uri, attributes)
+      updated_item, _response = put(uri, attributes)
       updated_item
     end
-
   end
-
 end

--- a/lib/boxr/collaborations.rb
+++ b/lib/boxr/collaborations.rb
@@ -1,12 +1,11 @@
 module Boxr
   class Client
-
     def folder_collaborations(folder, fields: [])
       folder_id = ensure_id(folder)
       query = build_fields_query(fields, COLLABORATION_FIELDS_QUERY)
       uri = "#{FOLDERS_URI}/#{folder_id}/collaborations"
 
-      collaborations, response = get(uri, query: query)
+      collaborations, _response = get(uri, query: query)
       collaborations['entries']
     end
 
@@ -15,11 +14,11 @@ module Boxr
       query = build_fields_query(fields, COLLABORATION_FIELDS_QUERY)
       query[:notify] = :notify unless notify.nil?
 
-      attributes = {item: {id: folder_id, type: :folder}}
+      attributes = { item: { id: folder_id, type: :folder } }
       attributes[:accessible_by] = accessible_by
       attributes[:role] = validate_role(role)
 
-      collaboration, response = post(COLLABORATIONS_URI, attributes, query: query)
+      collaboration, _response = post(COLLABORATIONS_URI, attributes, query: query)
       collaboration
     end
 
@@ -30,14 +29,14 @@ module Boxr
       attributes[:role] = validate_role(role) unless role.nil?
       attributes[:status] = status unless status.nil?
 
-      updated_collaboration, response = put(uri, attributes)
+      updated_collaboration, _response = put(uri, attributes)
       updated_collaboration
     end
 
     def remove_collaboration(collaboration)
       collaboration_id = ensure_id(collaboration)
       uri = "#{COLLABORATIONS_URI}/#{collaboration_id}"
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
 
@@ -48,21 +47,21 @@ module Boxr
       query = build_fields_query(fields, COLLABORATION_FIELDS_QUERY)
       query[:status] = status unless status.nil?
 
-      collaboration, response = get(uri, query: query)
+      collaboration, _response = get(uri, query: query)
       collaboration
     end
 
-    #these are pending collaborations for the current user; use the As-User Header to request for different users
+    # these are pending collaborations for the current user; use the As-User
+    # Header to request for different users
     def pending_collaborations(fields: [])
       query = build_fields_query(fields, COLLABORATION_FIELDS_QUERY)
       query[:status] = :pending
-      pending_collaborations, response = get(COLLABORATIONS_URI, query: query)
+      pending_collaborations, _response = get(COLLABORATIONS_URI, query: query)
       pending_collaborations['entries']
     end
 
-
     private
-    
+
     def validate_role(role)
       case role
       when :previewer_uploader
@@ -75,7 +74,7 @@ module Boxr
 
       role = role.to_s
       raise BoxrError.new(boxr_message: "Invalid collaboration role: '#{role}'") unless VALID_COLLABORATION_ROLES.include?(role)
-      
+
       role
     end
   end

--- a/lib/boxr/collections.rb
+++ b/lib/boxr/collections.rb
@@ -1,16 +1,15 @@
 module Boxr
   class Client
-
     def collections
-      collections = get_all_with_pagination(COLLECTIONS_URI, offset: 0, limit: DEFAULT_LIMIT)
+      get_all_with_pagination(COLLECTIONS_URI, offset: 0, limit: DEFAULT_LIMIT)
     end
 
     def collection_items(collection, fields: [])
       collection_id = ensure_id(collection)
       uri = "#{COLLECTIONS_URI}/#{collection_id}/items"
       query = build_fields_query(fields, FOLDER_AND_FILE_FIELDS_QUERY)
-      items = get_all_with_pagination(uri, query: query, offset: 0, limit: DEFAULT_LIMIT)
+      get_all_with_pagination(uri, query: query, offset: 0,
+                                   limit: DEFAULT_LIMIT)
     end
-
   end
 end

--- a/lib/boxr/comments.rb
+++ b/lib/boxr/comments.rb
@@ -1,12 +1,11 @@
 module Boxr
   class Client
-
     def file_comments(file, fields: [])
       file_id = ensure_id(file)
       uri = "#{FILES_URI}/#{file_id}/comments"
       query = build_fields_query(fields, COMMENT_FIELDS_QUERY)
 
-      comments = get_all_with_pagination(uri, query: query, offset: 0, limit: DEFAULT_LIMIT)
+      get_all_with_pagination(uri, query: query, offset: 0, limit: DEFAULT_LIMIT)
     end
 
     def add_comment_to_file(file, message: nil, tagged_message: nil)
@@ -22,38 +21,36 @@ module Boxr
     def change_comment(comment, message)
       comment_id = ensure_id(comment)
       uri = "#{COMMENTS_URI}/#{comment_id}"
-      attributes = {message: message}
-      updated_comment, response = put(uri, attributes)
+      attributes = { message: message }
+      updated_comment, _response = put(uri, attributes)
       updated_comment
     end
 
-    def comment_from_id(comment_id, fields: [])
+    def comment_from_id(comment_id)
       comment_id = ensure_id(comment_id)
-      uri ="#{COMMENTS_URI}/#{comment_id}"
-      comment, response = get(uri)
+      uri = "#{COMMENTS_URI}/#{comment_id}"
+      comment, _response = get(uri)
       comment
     end
-    alias :comment :comment_from_id
+    alias comment comment_from_id
 
     def delete_comment(comment)
       comment_id = ensure_id(comment)
       uri = "#{COMMENTS_URI}/#{comment_id}"
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
-
 
     private
 
     def add_comment(type, id, message, tagged_message)
       uri = COMMENTS_URI
-      attributes = {item: {type: type, id: id}}
+      attributes = { item: { type: type, id: id } }
       attributes[:message] = message unless message.nil?
       attributes[:tagged_message] = tagged_message unless tagged_message.nil?
 
-      new_comment, response = post(uri, attributes)
+      new_comment, _response = post(uri, attributes)
       new_comment
     end
-
   end
 end

--- a/lib/boxr/errors.rb
+++ b/lib/boxr/errors.rb
@@ -1,7 +1,5 @@
 module Boxr
-
   class BoxrError < StandardError
-
     attr_reader :response_body, :type, :status, :code, :help_uri, :box_message, :boxr_message, :request_id
 
     def initialize(status: nil, body: nil, header: nil, boxr_message: nil)
@@ -10,17 +8,17 @@ module Boxr
       @header = header
       @boxr_message = boxr_message
 
-      if(body)
+      if body
         begin
           body_json = Oj.load(body)
 
           if body_json
-            @type = body_json["type"]
-            @box_status = body_json["status"]
-            @code = body_json["code"]
-            @help_uri = body_json["help_uri"]
-            @box_message = body_json["message"]
-            @request_id = body_json["request_id"]
+            @type = body_json['type']
+            @box_status = body_json['status']
+            @code = body_json['code']
+            @help_uri = body_json['help_uri']
+            @box_message = body_json['message']
+            @request_id = body_json['request_id']
           end
         rescue
         end
@@ -29,11 +27,11 @@ module Boxr
 
     def message
       auth_header = @header['WWW-Authenticate'][0] unless @header.nil?
-      if(auth_header && auth_header != [])
+      if auth_header && auth_header != []
         "#{@status}: #{auth_header}"
-      elsif(@box_message)
+      elsif @box_message
         "#{@status}: #{@box_message}"
-      elsif(@boxr_message)
+      elsif @boxr_message
         @boxr_message
       else
         "#{@status}: #{@response_body}"
@@ -44,5 +42,4 @@ module Boxr
       message
     end
   end
-
 end

--- a/lib/boxr/events.rb
+++ b/lib/boxr/events.rb
@@ -1,11 +1,10 @@
 module Boxr
   class Client
-
     def user_events(stream_position, stream_type: :all, limit: 800)
-      query = {stream_position: stream_position, stream_type: stream_type, limit: limit}
-      
-      events, response = get(EVENTS_URI, query: query)
-      BoxrMash.new({events: events.entries, chunk_size: events.chunk_size, next_stream_position: events.next_stream_position})
+      query = { stream_position: stream_position, stream_type: stream_type, limit: limit }
+
+      events, _response = get(EVENTS_URI, query: query)
+      BoxrMash.new(events: events.entries, chunk_size: events.chunk_size, next_stream_position: events.next_stream_position)
     end
 
     def enterprise_events(created_after: nil, created_before: nil, stream_position: 0, event_type: nil, limit: 500)
@@ -17,7 +16,7 @@ module Boxr
 
         break if event_response.events.empty?
       end
-      BoxrMash.new({events: events, next_stream_position: stream_position})
+      BoxrMash.new(events: events, next_stream_position: stream_position)
     end
 
     def enterprise_events_stream(initial_stream_position, event_type: nil, limit: 500, refresh_period: 300)
@@ -26,24 +25,22 @@ module Boxr
         response = enterprise_events(stream_position: stream_position, event_type: event_type, limit: limit)
 
         yield(response) if block_given?
-        
+
         stream_position = response.next_stream_position
         sleep refresh_period
       end
     end
 
-
     private
 
     def get_enterprise_events(created_after, created_before, stream_position, event_type, limit)
-      query = {stream_position: stream_position, stream_type: :admin_logs, limit: limit}
+      query = { stream_position: stream_position, stream_type: :admin_logs, limit: limit }
       query['event_type'] = event_type unless event_type.nil?
       query['created_after'] = created_after.to_datetime.rfc3339 unless created_after.nil?
       query['created_before'] = created_before.to_datetime.rfc3339 unless created_before.nil?
 
-      events, response = get(EVENTS_URI, query: query)
-      BoxrMash.new({events: events.entries, chunk_size: events.chunk_size, next_stream_position: events.next_stream_position})
+      events, _response = get(EVENTS_URI, query: query)
+      BoxrMash.new(events: events.entries, chunk_size: events.chunk_size, next_stream_position: events.next_stream_position)
     end
-
   end
 end

--- a/lib/boxr/folders.rb
+++ b/lib/boxr/folders.rb
@@ -1,16 +1,13 @@
 module Boxr
   class Client
-
     def folder_from_path(path)
-      if(path.start_with?('/'))
-        path = path.slice(1..-1)
-      end
+      path = path.slice(1..-1) if path.start_with?('/')
 
       path_folders = path.split('/')
 
       folder = path_folders.inject(Boxr::ROOT) do |parent_folder, folder_name|
         folders = folder_items(parent_folder, fields: [:id, :name]).folders
-        folder = folders.select{|f| f.name == folder_name}.first
+        folder = folders.select { |f| f.name == folder_name }.first
         raise BoxrError.new(boxr_message: "Folder not found: '#{folder_name}'") if folder.nil?
         folder
       end
@@ -21,10 +18,10 @@ module Boxr
       query = build_fields_query(fields, FOLDER_AND_FILE_FIELDS_QUERY)
       uri = "#{FOLDERS_URI}/#{folder_id}"
 
-      folder, response = get(uri, query: query)
+      folder, _response = get(uri, query: query)
       folder
     end
-    alias :folder :folder_from_id
+    alias folder folder_from_id
 
     def folder_items(folder, fields: [], offset: nil, limit: nil)
       folder_id = ensure_id(folder)
@@ -32,11 +29,12 @@ module Boxr
       uri = "#{FOLDERS_URI}/#{folder_id}/items"
 
       if offset.nil? || limit.nil?
-        items = get_all_with_pagination(uri, query: query, offset: 0, limit: FOLDER_ITEMS_LIMIT)
+        get_all_with_pagination(uri, query: query, offset: 0,
+                                     limit: FOLDER_ITEMS_LIMIT)
       else
         query[:offset] = offset
         query[:limit] = limit
-        items, response = get(uri, query: query)
+        items, _response = get(uri, query: query)
         items['entries']
       end
     end
@@ -48,16 +46,16 @@ module Boxr
     def create_folder(name, parent)
       parent_id = ensure_id(parent)
 
-      uri = "#{FOLDERS_URI}"
-      attributes = {:name => name, :parent => {:id => parent_id}}
+      uri = FOLDERS_URI.to_s
+      attributes = { name: name, parent: { id: parent_id } }
 
-      created_folder, response = post(uri, attributes)
+      created_folder, _response = post(uri, attributes)
       created_folder
     end
 
     def update_folder(folder, name: nil, description: nil, parent: nil, shared_link: nil,
-                           folder_upload_email_access: nil, owned_by: nil, sync_state: nil, tags: nil,
-                           can_non_owners_invite: nil, if_match: nil)
+                      folder_upload_email_access: nil, owned_by: nil, sync_state: nil, tags: nil,
+                      can_non_owners_invite: nil, if_match: nil)
       folder_id = ensure_id(folder)
       parent_id = ensure_id(parent)
       owned_by_id = ensure_id(owned_by)
@@ -66,15 +64,15 @@ module Boxr
       attributes = {}
       attributes[:name] = name unless name.nil?
       attributes[:description] = description unless description.nil?
-      attributes[:parent] = {id: parent_id} unless parent_id.nil?
+      attributes[:parent] = { id: parent_id } unless parent_id.nil?
       attributes[:shared_link] = shared_link unless shared_link.nil?
-      attributes[:folder_upload_email] = {access: folder_upload_email_access} unless folder_upload_email_access.nil?
-      attributes[:owned_by] = {id: owned_by_id} unless owned_by_id.nil?
+      attributes[:folder_upload_email] = { access: folder_upload_email_access } unless folder_upload_email_access.nil?
+      attributes[:owned_by] = { id: owned_by_id } unless owned_by_id.nil?
       attributes[:sync_state] = sync_state unless sync_state.nil?
       attributes[:tags] = tags unless tags.nil?
       attributes[:can_non_owners_invite] = can_non_owners_invite unless can_non_owners_invite.nil?
 
-      updated_folder, response = put(uri, attributes, if_match: if_match)
+      updated_folder, _response = put(uri, attributes, if_match: if_match)
       updated_folder
     end
 
@@ -85,9 +83,9 @@ module Boxr
     def delete_folder(folder, recursive: false, if_match: nil)
       folder_id = ensure_id(folder)
       uri = "#{FOLDERS_URI}/#{folder_id}"
-      query = {:recursive => recursive}
+      query = { recursive: recursive }
 
-      result, response = delete(uri, query: query, if_match: if_match)
+      result, _response = delete(uri, query: query, if_match: if_match)
       result
     end
 
@@ -96,10 +94,10 @@ module Boxr
       dest_folder_id = ensure_id(dest_folder)
 
       uri = "#{FOLDERS_URI}/#{folder_id}/copy"
-      attributes = {:parent => {:id => dest_folder_id}}
+      attributes = { parent: { id: dest_folder_id } }
       attributes[:name] = name unless name.nil?
 
-      new_folder, response = post(uri, attributes)
+      new_folder, _response = post(uri, attributes)
       new_folder
     end
 
@@ -120,11 +118,12 @@ module Boxr
       query = build_fields_query(fields, FOLDER_AND_FILE_FIELDS_QUERY)
 
       if offset.nil? || limit.nil?
-        items = get_all_with_pagination(uri, query: query, offset: 0, limit: FOLDER_ITEMS_LIMIT)
+        get_all_with_pagination(uri, query: query, offset: 0,
+                                     limit: FOLDER_ITEMS_LIMIT)
       else
         query[:offset] = offset
         query[:limit] = limit
-        items, response = get(uri, query: query)
+        items, _response = get(uri, query: query)
         items['entries']
       end
     end
@@ -134,14 +133,14 @@ module Boxr
       uri = "#{FOLDERS_URI}/#{folder_id}/trash"
       query = build_fields_query(fields, FOLDER_AND_FILE_FIELDS_QUERY)
 
-      folder, response = get(uri, query: query)
+      folder, _response = get(uri, query: query)
       folder
     end
 
     def delete_trashed_folder(folder)
       folder_id = ensure_id(folder)
       uri = "#{FOLDERS_URI}/#{folder_id}/trash"
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
 
@@ -152,6 +151,5 @@ module Boxr
       uri = "#{FOLDERS_URI}/#{folder_id}"
       restore_trashed_item(uri, name, parent_id)
     end
-
   end
 end

--- a/lib/boxr/groups.rb
+++ b/lib/boxr/groups.rb
@@ -1,89 +1,87 @@
 module Boxr
   class Client
-
     def groups(fields: [])
       query = build_fields_query(fields, GROUP_FIELDS_QUERY)
-      groups = get_all_with_pagination(GROUPS_URI, query: query, offset: 0, limit: DEFAULT_LIMIT)
+      get_all_with_pagination(GROUPS_URI, query: query, offset: 0, limit: DEFAULT_LIMIT)
     end
 
     def create_group(name)
-      attributes = {name: name}
-      new_group, response = post(GROUPS_URI, attributes)
-      new_group 
+      attributes = { name: name }
+      new_group, _response = post(GROUPS_URI, attributes)
+      new_group
     end
 
     def update_group(group, name)
       group_id = ensure_id(group)
       uri = "#{GROUPS_URI}/#{group_id}"
-      attributes = {name: name}
+      attributes = { name: name }
 
-      updated_group, response = put(uri, attributes)
+      updated_group, _response = put(uri, attributes)
       updated_group
     end
-    alias :rename_group :update_group
+    alias rename_group update_group
 
     def delete_group(group)
       group_id = ensure_id(group)
       uri = "#{GROUPS_URI}/#{group_id}"
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
 
     def group_memberships(group)
       group_id = ensure_id(group)
       uri = "#{GROUPS_URI}/#{group_id}/memberships"
-      memberships = get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
+      get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
     end
 
     def group_memberships_for_user(user)
       user_id = ensure_id(user)
       uri = "#{USERS_URI}/#{user_id}/memberships"
-      memberships = get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
+      get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
     end
 
     def group_memberships_for_me
       uri = "#{USERS_URI}/me/memberships"
-      memberships = get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
+      get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
     end
 
     def group_membership_from_id(membership_id)
       membership_id = ensure_id(membership_id)
       uri = "#{GROUP_MEMBERSHIPS_URI}/#{membership_id}"
-      membership, response = get(uri)
+      membership, _response = get(uri)
       membership
     end
-    alias :group_membership :group_membership_from_id
+    alias group_membership group_membership_from_id
 
     def add_user_to_group(user, group, role: nil)
       user_id = ensure_id(user)
       group_id = ensure_id(group)
 
-      attributes = {user: {id: user_id}, group: {id: group_id}}
+      attributes = { user: { id: user_id }, group: { id: group_id } }
       attributes[:role] = role unless role.nil?
-      membership, response = post(GROUP_MEMBERSHIPS_URI, attributes)
+      membership, _response = post(GROUP_MEMBERSHIPS_URI, attributes)
       membership
     end
 
     def update_group_membership(membership, role)
       membership_id = ensure_id(membership)
       uri = "#{GROUP_MEMBERSHIPS_URI}/#{membership_id}"
-      attributes = {role: role}
-      updated_membership, response = put(uri, attributes)
+      attributes = { role: role }
+      updated_membership, _response = put(uri, attributes)
       updated_membership
     end
 
     def delete_group_membership(membership)
       membership_id = ensure_id(membership)
       uri = "#{GROUP_MEMBERSHIPS_URI}/#{membership_id}"
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
 
     def group_collaborations(group)
       group_id = ensure_id(group)
       uri = "#{GROUPS_URI}/#{group_id}/collaborations"
-      collaborations = get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
+      get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
     end
-
   end
 end

--- a/lib/boxr/metadata.rb
+++ b/lib/boxr/metadata.rb
@@ -1,38 +1,37 @@
 module Boxr
   class Client
-
     def create_metadata(file, metadata, scope: :global, template: :properties)
       file_id = ensure_id(file)
       uri = "#{FILE_METADATA_URI}/#{file_id}/metadata/#{scope}/#{template}"
-      metadata, response = post(uri, metadata, content_type: "application/json")
+      metadata, _response = post(uri, metadata, content_type: 'application/json')
       metadata
     end
 
     def create_folder_metadata(folder, metadata, scope, template)
       folder_id = ensure_id(folder)
       uri = "#{FOLDER_METADATA_URI}/#{folder_id}/metadata/#{scope}/#{template}"
-      metadata, response = post(uri, metadata, content_type: "application/json")
+      metadata, _response = post(uri, metadata, content_type: 'application/json')
       metadata
     end
 
     def metadata(file, scope: :global, template: :properties)
       file_id = ensure_id(file)
       uri = "#{FILE_METADATA_URI}/#{file_id}/metadata/#{scope}/#{template}"
-      metadata, response = get(uri)
+      metadata, _response = get(uri)
       metadata
     end
 
     def folder_metadata(folder, scope, template)
       folder_id = ensure_id(folder)
       uri = "#{FOLDER_METADATA_URI}/#{folder_id}/metadata/#{scope}/#{template}"
-      metadata, response = get(uri)
+      metadata, _response = get(uri)
       metadata
     end
 
     def all_metadata(file)
       file_id = ensure_id(file)
       uri = "#{FILE_METADATA_URI}/#{file_id}/metadata"
-      all_metadata, response = get(uri)
+      all_metadata, _response = get(uri)
       all_metadata
     end
 
@@ -40,10 +39,11 @@ module Boxr
       file_id = ensure_id(file)
       uri = "#{FILE_METADATA_URI}/#{file_id}/metadata/#{scope}/#{template}"
 
-      #in the event just one update is specified ensure that it is packaged inside an array
+      # in the event just one update is specified ensure that it is packaged
+      # inside an array
       updates = [updates] unless updates.is_a? Array
 
-      metadata, response = put(uri, updates, content_type: "application/json-patch+json")
+      metadata, _response = put(uri, updates, content_type: 'application/json-patch+json')
       metadata
     end
 
@@ -51,38 +51,38 @@ module Boxr
       folder_id = ensure_id(folder)
       uri = "#{FOLDER_METADATA_URI}/#{folder_id}/metadata/#{scope}/#{template}"
 
-      #in the event just one update is specified ensure that it is packaged inside an array
+      # in the event just one update is specified ensure that it is packaged
+      # inside an array
       updates = [updates] unless updates.is_a? Array
 
-      metadata, response = put(uri, updates, content_type: "application/json-patch+json")
+      metadata, _response = put(uri, updates, content_type: 'application/json-patch+json')
       metadata
     end
 
     def delete_metadata(file, scope: :global, template: :properties)
       file_id = ensure_id(file)
       uri = "#{FILE_METADATA_URI}/#{file_id}/metadata/#{scope}/#{template}"
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
 
     def delete_folder_metadata(folder, scope, template)
       folder_id = ensure_id(folder)
       uri = "#{FOLDER_METADATA_URI}/#{folder_id}/metadata/#{scope}/#{template}"
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
 
     def enterprise_metadata
       uri = "#{METADATA_TEMPLATES_URI}/enterprise"
-      ent_metadata, response = get(uri)
+      ent_metadata, _response = get(uri)
       ent_metadata
     end
 
     def metadata_schema(scope, template_key)
       uri = "#{METADATA_TEMPLATES_URI}/#{scope}/#{template_key}/schema"
-      schema, response = get(uri)
+      schema, _response = get(uri)
       schema
     end
-
   end
 end

--- a/lib/boxr/search.rb
+++ b/lib/boxr/search.rb
@@ -1,29 +1,30 @@
 module Boxr
   class Client
+    def search(query = nil, scope: nil, file_extensions: [],
+               created_at_range_from_date: nil, created_at_range_to_date: nil,
+               updated_at_range_from_date: nil, updated_at_range_to_date: nil,
+               size_range_lower_bound_bytes: nil, size_range_upper_bound_bytes: nil,
+               owner_user_ids: [], ancestor_folder_ids: [], content_types: [], trash_content: nil,
+               mdfilters: nil, type: nil, limit: 30, offset: 0)
 
-    def search( query=nil, scope: nil, file_extensions: [], 
-                created_at_range_from_date: nil, created_at_range_to_date: nil,
-                updated_at_range_from_date: nil, updated_at_range_to_date: nil,
-                size_range_lower_bound_bytes: nil, size_range_upper_bound_bytes: nil, 
-                owner_user_ids: [], ancestor_folder_ids: [], content_types: [], trash_content: nil, 
-                mdfilters: nil, type: nil, limit: 30, offset: 0)
-
-      
       unless mdfilters.nil?
-        unless mdfilters.is_a? String   #if a string is passed in assume it is already formatted correctly
-          unless mdfilters.is_a? Array  
-            mdfilters = [mdfilters]     #if just one mdfilter is specified ensure that it is packaged inside an array
+        # if a string is passed in assume it is already formatted correctly
+        unless mdfilters.is_a? String
+          unless mdfilters.is_a? Array
+            # if just one mdfilter is specified ensure that it is packaged
+            # inside an array
+            mdfilters = [mdfilters]
           end
-          mdfilters = Oj.dump(mdfilters) 
+          mdfilters = Oj.dump(mdfilters)
         end
       end
 
-      #build range strings
+      # build range strings
       created_at_range_string = build_date_range_field(created_at_range_from_date, created_at_range_to_date)
       updated_at_range_string = build_date_range_field(updated_at_range_from_date, updated_at_range_to_date)
       size_range_string = build_size_range_field(size_range_lower_bound_bytes, size_range_upper_bound_bytes)
 
-      #build comma separated strings
+      # build comma separated strings
       file_extensions_string = to_comma_separated_string(file_extensions)
       owner_user_ids_string = to_comma_separated_string(owner_user_ids)
       ancestor_folder_ids_string = to_comma_separated_string(ancestor_folder_ids)
@@ -45,23 +46,22 @@ module Boxr
       search_query[:limit] = limit unless limit.nil?
       search_query[:offset] = offset unless offset.nil?
 
-      results, response = get(SEARCH_URI, query: search_query)
+      results, _response = get(SEARCH_URI, query: search_query)
       results.entries
     end
 
     private
 
     def build_date_range_field(from, to)
-      from_string = from.nil? ? "" : from.to_datetime.rfc3339
-      to_string = to.nil? ? "" : to.to_datetime.rfc3339
+      from_string = from.nil? ? '' : from.to_datetime.rfc3339
+      to_string = to.nil? ? '' : to.to_datetime.rfc3339
       build_range_string(from_string, to_string)
     end
 
     def build_size_range_field(lower, upper)
-      lower_string = lower.nil? ? "" : lower.to_i
-      upper_string = upper.nil? ? "" : upper.to_i
+      lower_string = lower.nil? ? '' : lower.to_i
+      upper_string = upper.nil? ? '' : upper.to_i
       build_range_string(lower_string, upper_string)
     end
-
   end
 end

--- a/lib/boxr/shared_items.rb
+++ b/lib/boxr/shared_items.rb
@@ -1,13 +1,11 @@
 module Boxr
   class Client
-
     def shared_item(shared_link, shared_link_password: nil)
       box_api_header = "shared_link=#{shared_link}"
       box_api_header += "&shared_link_password=#{shared_link_password}" unless shared_link_password.nil?
 
-      file_or_folder, response = get(SHARED_ITEMS_URI, box_api_header: box_api_header)
+      file_or_folder, _response = get(SHARED_ITEMS_URI, box_api_header: box_api_header)
       file_or_folder
     end
-
   end
 end

--- a/lib/boxr/tasks.rb
+++ b/lib/boxr/tasks.rb
@@ -1,33 +1,32 @@
 module Boxr
   class Client
-
     def file_tasks(file, fields: [])
       file_id = ensure_id(file)
       uri = "#{FILES_URI}/#{file_id}/tasks"
       query = build_fields_query(fields, TASK_FIELDS_QUERY)
 
-      tasks, response = get(uri, query: query)
+      tasks, _response = get(uri, query: query)
       tasks.entries
     end
 
     def create_task(file, action: :review, message: nil, due_at: nil)
       file_id = ensure_id(file)
-      attributes = {item: {type: :file, id: file_id}}
+      attributes = { item: { type: :file, id: file_id } }
       attributes[:action] = action unless action.nil?
       attributes[:message] = message unless message.nil?
       attributes[:due_at] = due_at.to_datetime.rfc3339 unless due_at.nil?
 
-      new_task, response = post(TASKS_URI, attributes)
+      new_task, _response = post(TASKS_URI, attributes)
       new_task
     end
 
     def task_from_id(task_id)
       task_id = ensure_id(task_id)
       uri = "#{TASKS_URI}/#{task_id}"
-      task, response = get(uri)
+      task, _response = get(uri)
       task
     end
-    alias :task :task_from_id
+    alias task task_from_id
 
     def update_task(task, action: :review, message: nil, due_at: nil)
       task_id = ensure_id(task)
@@ -37,48 +36,48 @@ module Boxr
       attributes[:message] = message unless message.nil?
       attributes[:due_at] = due_at.to_datetime.rfc3339 unless due_at.nil?
 
-      task, response = put(uri, attributes)
+      task, _response = put(uri, attributes)
       task
     end
 
     def delete_task(task)
       task_id = ensure_id(task)
       uri = "#{TASKS_URI}/#{task_id}"
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
 
     def task_assignments(task)
       task_id = ensure_id(task)
       uri = "#{TASKS_URI}/#{task_id}/assignments"
-      assignments, response = get(uri)
+      assignments, _response = get(uri)
       assignments['entries']
     end
 
     def create_task_assignment(task, assign_to: nil, assign_to_login: nil)
       task_id = ensure_id(task)
       assign_to_id = ensure_id(assign_to)
-      attributes = {task: {type: :task, id: "#{task_id}"}}
-      
-      attributes[:assign_to] = {} 
+      attributes = { task: { type: :task, id: task_id.to_s } }
+
+      attributes[:assign_to] = {}
       attributes[:assign_to][:login] = assign_to_login unless assign_to_login.nil?
       attributes[:assign_to][:id] = assign_to_id unless assign_to_id.nil?
 
-      new_task_assignment, response = post(TASK_ASSIGNMENTS_URI, attributes)
+      new_task_assignment, _response = post(TASK_ASSIGNMENTS_URI, attributes)
       new_task_assignment
     end
 
     def task_assignment(task)
       task_id = ensure_id(task)
       uri = "#{TASK_ASSIGNMENTS_URI}/#{task_id}"
-      task_assignment, response = get(uri)
+      task_assignment, _response = get(uri)
       task_assignment
     end
 
     def delete_task_assignment(task)
       task_id = ensure_id(task)
       uri = "#{TASK_ASSIGNMENTS_URI}/#{task_id}"
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
 
@@ -89,9 +88,8 @@ module Boxr
       attributes[:message] = message unless message.nil?
       attributes[:resolution_state] = resolution_state unless resolution_state.nil?
 
-      updated_task, response = put(uri, attributes)
+      updated_task, _response = put(uri, attributes)
       updated_task
     end
-
   end
 end

--- a/lib/boxr/users.rb
+++ b/lib/boxr/users.rb
@@ -1,24 +1,23 @@
 module Boxr
   class Client
-
     def current_user(fields: [])
       uri = "#{USERS_URI}/me"
       query = build_fields_query(fields, USER_FIELDS_QUERY)
-      
-      user, response = get(uri, query: query)
+
+      user, _response = get(uri, query: query)
       user
     end
-    alias :me :current_user
+    alias me current_user
 
     def user_from_id(user_id, fields: [])
       user_id = ensure_id(user_id)
       uri = "#{USERS_URI}/#{user_id}"
       query = build_fields_query(fields, USER_FIELDS_QUERY)
-      
-      user, response = get(uri, query: query)
+
+      user, _response = get(uri, query: query)
       user
     end
-    alias :user :user_from_id
+    alias user user_from_id
 
     def all_users(filter_term: nil, fields: [], offset: nil, limit: nil)
       uri = USERS_URI
@@ -26,30 +25,32 @@ module Boxr
       query[:filter_term] = filter_term unless filter_term.nil?
 
       if offset.nil? || limit.nil?
-        users = get_all_with_pagination(uri, query: query, offset: 0, limit: DEFAULT_LIMIT)
+        get_all_with_pagination(uri, query: query, offset: 0, limit: DEFAULT_LIMIT)
       else
         query[:offset] = offset
         query[:limit] = limit
-        
-        users, response = get(uri, query: query)
+
+        users, _response = get(uri, query: query)
         users['entries']
       end
     end
 
     def create_user(name, login: nil, role: nil, language: nil, is_sync_enabled: nil, job_title: nil,
-                                 phone: nil, address: nil, space_amount: nil, tracking_codes: nil,
-                                 can_see_managed_users: nil, is_external_collab_restricted: nil, status: nil, timezone: nil,
-                                 is_exempt_from_device_limits: nil, is_exempt_from_login_verification: nil,
-                                 is_platform_access_only: nil)
+                    phone: nil, address: nil, space_amount: nil, tracking_codes: nil,
+                    can_see_managed_users: nil, is_external_collab_restricted: nil, status: nil, timezone: nil,
+                    is_exempt_from_device_limits: nil, is_exempt_from_login_verification: nil,
+                    is_platform_access_only: nil)
 
       uri = USERS_URI
-      attributes = {name: name}
-      attributes[:login] = login unless login.nil? #login is not required for platform users, so needed to make this optional
+      attributes = { name: name }
+      # login is not required for platform users, so needed to make this
+      # optional
+      attributes[:login] = login unless login.nil?
       attributes[:role] = role unless role.nil?
       attributes[:language] = language unless language.nil?
       attributes[:is_sync_enabled] = is_sync_enabled unless is_sync_enabled.nil?
       attributes[:job_title] = job_title unless job_title.nil?
-      attributes[:phone] = phone unless phone.nil? 
+      attributes[:phone] = phone unless phone.nil?
       attributes[:address] = address unless address.nil?
       attributes[:space_amount] = space_amount unless space_amount.nil?
       attributes[:tracking_codes] = tracking_codes unless tracking_codes.nil?
@@ -57,25 +58,27 @@ module Boxr
       attributes[:is_external_collab_restricted] = is_external_collab_restricted unless is_external_collab_restricted.nil?
       attributes[:status] = status unless status.nil?
       attributes[:timezone] = timezone unless timezone.nil?
-      attributes[:is_exempt_from_device_limits] = is_exempt_from_device_limits unless is_exempt_from_device_limits.nil? 
+      attributes[:is_exempt_from_device_limits] = is_exempt_from_device_limits unless is_exempt_from_device_limits.nil?
       attributes[:is_exempt_from_login_verification] = is_exempt_from_login_verification unless is_exempt_from_login_verification.nil?
       attributes[:is_platform_access_only] = is_platform_access_only unless is_platform_access_only.nil?
 
-      new_user, response = post(uri, attributes)
+      new_user, _response = post(uri, attributes)
       new_user
     end
 
     def update_user(user, notify: nil, enterprise: true, name: nil, role: nil, language: nil, is_sync_enabled: nil,
-                             job_title: nil, phone: nil, address: nil, space_amount: nil, tracking_codes: nil,
-                             can_see_managed_users: nil, status: nil, timezone: nil, is_exempt_from_device_limits: nil,
-                             is_exempt_from_login_verification: nil, is_exempt_from_reset_required: nil, is_external_collab_restricted: nil)
+                    job_title: nil, phone: nil, address: nil, space_amount: nil, tracking_codes: nil,
+                    can_see_managed_users: nil, status: nil, timezone: nil, is_exempt_from_device_limits: nil,
+                    is_exempt_from_login_verification: nil, is_exempt_from_reset_required: nil, is_external_collab_restricted: nil)
 
       user_id = ensure_id(user)
       uri = "#{USERS_URI}/#{user_id}"
-      query = {notify: notify} unless notify.nil?
-      
+      query = { notify: notify } unless notify.nil?
+
       attributes = {}
-      attributes[:enterprise] = nil if enterprise.nil? #this is a special condition where setting this to nil means to roll this user out of the enterprise 
+      # this is a special condition where setting this to nil means to roll this
+      # user out of the enterprise
+      attributes[:enterprise] = nil if enterprise.nil?
       attributes[:name] = name unless name.nil?
       attributes[:role] = role unless role.nil?
       attributes[:language] = language unless language.nil?
@@ -93,7 +96,7 @@ module Boxr
       attributes[:is_exempt_from_reset_required] = is_exempt_from_reset_required unless is_exempt_from_reset_required.nil?
       attributes[:is_external_collab_restricted] = is_external_collab_restricted unless is_external_collab_restricted.nil?
 
-      updated_user, response = put(uri, attributes, query: query)
+      updated_user, _response = put(uri, attributes, query: query)
       updated_user
     end
 
@@ -104,7 +107,7 @@ module Boxr
       query[:notify] = notify unless notify.nil?
       query[:force] = force unless force.nil?
 
-      result, response = delete(uri, query: query)
+      result, _response = delete(uri, query: query)
       result
     end
 
@@ -112,16 +115,16 @@ module Boxr
       user_id = ensure_id(user)
       uri = "#{USERS_URI}/#{user_id}/email_aliases"
 
-      aliases, response = get(uri)
+      aliases, _response = get(uri)
       aliases['entries']
     end
 
     def add_email_alias_for_user(user, email)
       user_id = ensure_id(user)
       uri = "#{USERS_URI}/#{user_id}/email_aliases"
-      attributes = {email: email}
+      attributes = { email: email }
 
-      updated_user, response = post(uri, attributes)
+      updated_user, _response = post(uri, attributes)
       updated_user
     end
 
@@ -130,9 +133,8 @@ module Boxr
       email_alias_id = ensure_id(email_alias)
       uri = "#{USERS_URI}/#{user_id}/email_aliases/#{email_alias_id}"
 
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
-
   end
 end

--- a/lib/boxr/version.rb
+++ b/lib/boxr/version.rb
@@ -1,3 +1,3 @@
 module Boxr
-  VERSION = "1.2.0"
+  VERSION = '1.2.0'.freeze
 end

--- a/lib/boxr/web_links.rb
+++ b/lib/boxr/web_links.rb
@@ -1,33 +1,29 @@
 module Boxr
   class Client
-
     def create_web_link(url, parent, name: nil, description: nil)
-
       parent_id = ensure_id(parent)
       web_link_url = verify_url(url)
-      uri = "#{WEB_LINKS_URI}"
+      uri = WEB_LINKS_URI.to_s
 
       attributes = {}
       attributes[:url] = web_link_url
-      attributes[:parent] = {:id => parent_id}
+      attributes[:parent] = { id: parent_id }
       attributes[:name] = name unless name.nil?
       attributes[:description] = description unless description.nil?
 
-      created_link, response = post(uri, attributes)
+      created_link, _response = post(uri, attributes)
       created_link
     end
 
     def get_web_link(web_link)
-
       web_link_id = ensure_id(web_link)
       uri = "#{WEB_LINKS_URI}/#{web_link_id}"
 
-      web_link, response = get(uri)
+      web_link, _response = get(uri)
       web_link
     end
 
     def update_web_link(web_link, url: nil, parent: nil, name: nil, description: nil)
-
       web_link_id = ensure_id(web_link)
       parent_id = ensure_id(parent)
       uri = "#{WEB_LINKS_URI}/#{web_link_id}"
@@ -36,27 +32,25 @@ module Boxr
       attributes[:url] = url unless url.nil?
       attributes[:name] = name unless name.nil?
       attributes[:description] = description unless description.nil?
-      attributes[:parent] = {id: parent_id} unless parent_id.nil?
+      attributes[:parent] = { id: parent_id } unless parent_id.nil?
 
-      updated_web_link, response = put(uri, attributes)
+      updated_web_link, _response = put(uri, attributes)
       updated_web_link
     end
 
     def delete_web_link(web_link)
-
       web_link_id = ensure_id(web_link)
       uri = "#{WEB_LINKS_URI}/#{web_link_id}"
 
-      result, response = delete(uri)
+      result, _response = delete(uri)
       result
     end
 
     private
 
     def verify_url(item)
-      return item if item.class == String and (item.include? 'https://' or item.include? 'http://')
+      return item if item.class == String && (item.include?('https://') || item.include?('http://'))
       raise BoxrError.new(boxr_message: "Invalid url. Must include 'http://' or 'https://'")
     end
-
   end
 end

--- a/spec/boxr_spec.rb
+++ b/spec/boxr_spec.rb
@@ -1,55 +1,56 @@
 require 'spec_helper'
 
 describe Boxr::Client do
+  # PLEASE NOTE
+  # This test is intentionally NOT a series of unit tests.  The goal is to smoke
+  # test the entire code base against an actual Box account, making real calls
+  # to the Box API.  The Box API is subject to frequent changes and it is not
+  # sufficient to mock responses as those responses will change over time.
+  # Successfully running this test suite shows that the code base works with the
+  # current Box API.  The main premise here is that an exception will be thrown
+  # if anything unexpected happens.
 
-  #PLEASE NOTE
-  #This test is intentionally NOT a series of unit tests.  The goal is to smoke test the entire code base
-  #against an actual Box account, making real calls to the Box API.  The Box API is subject to frequent
-  #changes and it is not sufficient to mock responses as those responses will change over time.  Successfully
-  #running this test suite shows that the code base works with the current Box API.  The main premise here
-  #is that an exception will be thrown if anything unexpected happens.
-
-  #REQUIRED BOX SETTINGS
+  # REQUIRED BOX SETTINGS
   # 1. The developer token used must have admin or co-admin priviledges
-  # 2. Enterprise settings must allow Admin and Co-admins to permanently delete content in Trash
+  # 2. Enterprise settings must allow Admin and Co-admins to permanently delete
+  #    content in Trash
 
-  #follow the directions in .env.example to set up your BOX_DEVELOPER_TOKEN
-  #keep in mind it is only valid for 60 minutes
-  BOX_CLIENT = Boxr::Client.new #using ENV['BOX_DEVELOPER_TOKEN']
+  # follow the directions in .env.example to set up your BOX_DEVELOPER_TOKEN
+  # keep in mind it is only valid for 60 minutes
+  BOX_CLIENT = Boxr::Client.new # using ENV['BOX_DEVELOPER_TOKEN']
 
-  #uncomment this line to see the HTTP request and response debug info in the rspec output
+  # uncomment this line to see the HTTP request and response debug info in the
+  # rspec output
   # Boxr::turn_on_debugging
 
   BOX_SERVER_SLEEP = 5
-  TEST_FOLDER_NAME = 'Boxr Test'
-  SUB_FOLDER_NAME = 'sub_folder_1'
-  SUB_FOLDER_DESCRIPTION = 'This was created by the Boxr test suite'
-  TEST_FILE_NAME = 'test file.txt'
-  TEST_FILE_NAME_CUSTOM = 'test file custom.txt'
-  DOWNLOADED_TEST_FILE_NAME = 'downloaded test file.txt'
-  COMMENT_MESSAGE = 'this is a comment'
-  REPLY_MESSAGE = 'this is a comment reply'
-  CHANGED_COMMENT_MESSAGE = 'this comment has been changed'
-  TEST_USER_LOGIN = "test-boxr-user@#{('a'..'z').to_a.shuffle[0,10].join}.com" #needs to be unique across anyone running this test
-  TEST_USER_NAME = "Test Boxr User"
-  TEST_GROUP_NAME= "Test Boxr Group"
-  TEST_TASK_MESSAGE = "Please review"
-  TEST_WEB_URL = 'https://www.box.com'
-  TEST_WEB_URL2 = 'https://www.google.com'
+  TEST_FOLDER_NAME = 'Boxr Test'.freeze
+  SUB_FOLDER_NAME = 'sub_folder_1'.freeze
+  SUB_FOLDER_DESCRIPTION = 'This was created by the Boxr test suite'.freeze
+  TEST_FILE_NAME = 'test file.txt'.freeze
+  TEST_FILE_NAME_CUSTOM = 'test file custom.txt'.freeze
+  DOWNLOADED_TEST_FILE_NAME = 'downloaded test file.txt'.freeze
+  COMMENT_MESSAGE = 'this is a comment'.freeze
+  REPLY_MESSAGE = 'this is a comment reply'.freeze
+  CHANGED_COMMENT_MESSAGE = 'this comment has been changed'.freeze
+  TEST_USER_LOGIN = "test-boxr-user@#{('a'..'z').to_a.sample(10).join}.com".freeze # needs to be unique across anyone running this test
+  TEST_USER_NAME = 'Test Boxr User'.freeze
+  TEST_GROUP_NAME = 'Test Boxr Group'.freeze
+  TEST_TASK_MESSAGE = 'Please review'.freeze
+  TEST_WEB_URL = 'https://www.box.com'.freeze
+  TEST_WEB_URL2 = 'https://www.google.com'.freeze
 
   before(:each) do
-    puts "-----> Resetting Box Environment"
+    puts '-----> Resetting Box Environment'
     sleep BOX_SERVER_SLEEP
     root_folders = BOX_CLIENT.root_folder_items.folders
-    test_folder = root_folders.find{|f| f.name == TEST_FOLDER_NAME}
-    if(test_folder)
-      BOX_CLIENT.delete_folder(test_folder, recursive: true)
-    end
+    test_folder = root_folders.find { |f| f.name == TEST_FOLDER_NAME }
+    BOX_CLIENT.delete_folder(test_folder, recursive: true) if test_folder
     new_folder = BOX_CLIENT.create_folder(TEST_FOLDER_NAME, Boxr::ROOT)
     @test_folder = new_folder
 
     all_users = BOX_CLIENT.all_users
-    test_users = all_users.select{|u| u.name == TEST_USER_NAME}
+    test_users = all_users.select { |u| u.name == TEST_USER_NAME }
     test_users.each do |u|
       BOX_CLIENT.delete_user(u, force: true)
     end
@@ -58,493 +59,490 @@ describe Boxr::Client do
     @test_user = test_user
 
     all_groups = BOX_CLIENT.groups
-    test_group = all_groups.find{|g| g.name == TEST_GROUP_NAME}
-    if(test_group)
-      BOX_CLIENT.delete_group(test_group)
-    end
+    test_group = all_groups.find { |g| g.name == TEST_GROUP_NAME }
+    BOX_CLIENT.delete_group(test_group) if test_group
   end
 
   # use this command to just execute this scenario
   # rake spec SPEC_OPTS="-e \"invokes folder operations"\"
   it 'invokes folder operations' do
-    puts "get folder using path"
+    puts 'get folder using path'
     folder = BOX_CLIENT.folder_from_path(TEST_FOLDER_NAME)
     expect(folder.id).to eq(@test_folder.id)
 
-    puts "get folder info"
+    puts 'get folder info'
     folder = BOX_CLIENT.folder(@test_folder)
     expect(folder.id).to eq(@test_folder.id)
 
-    puts "create new folder"
+    puts 'create new folder'
     new_folder = BOX_CLIENT.create_folder(SUB_FOLDER_NAME, @test_folder)
     expect(new_folder).to be_a BoxrMash
     SUB_FOLDER = new_folder
 
-    puts "update folder"
+    puts 'update folder'
     updated_folder = BOX_CLIENT.update_folder(SUB_FOLDER, description: SUB_FOLDER_DESCRIPTION)
     expect(updated_folder.description).to eq(SUB_FOLDER_DESCRIPTION)
 
-    puts "copy folder"
-    new_folder = BOX_CLIENT.copy_folder(SUB_FOLDER,@test_folder, name: "copy of #{SUB_FOLDER_NAME}")
+    puts 'copy folder'
+    new_folder = BOX_CLIENT.copy_folder(SUB_FOLDER, @test_folder, name: "copy of #{SUB_FOLDER_NAME}")
     expect(new_folder).to be_a BoxrMash
     SUB_FOLDER_COPY = new_folder
 
-    puts "create shared link for folder"
+    puts 'create shared link for folder'
     updated_folder = BOX_CLIENT.create_shared_link_for_folder(@test_folder, access: :open)
-    expect(updated_folder.shared_link.access).to eq("open")
+    expect(updated_folder.shared_link.access).to eq('open')
     shared_link = updated_folder.shared_link.url
 
-    puts "inspect shared link"
+    puts 'inspect shared link'
     shared_item = BOX_CLIENT.shared_item(shared_link)
     expect(shared_item.id).to eq(@test_folder.id)
 
-    puts "disable shared link for folder"
+    puts 'disable shared link for folder'
     updated_folder = BOX_CLIENT.disable_shared_link_for_folder(@test_folder)
     expect(updated_folder.shared_link).to be_nil
 
-    puts "move folder"
-    folder_to_move = BOX_CLIENT.create_folder("Folder to move", @test_folder)
-    folder_to_move_into = BOX_CLIENT.create_folder("Folder to move into", @test_folder)
+    puts 'move folder'
+    folder_to_move = BOX_CLIENT.create_folder('Folder to move', @test_folder)
+    folder_to_move_into = BOX_CLIENT.create_folder('Folder to move into', @test_folder)
     folder_to_move = BOX_CLIENT.move_folder(folder_to_move, folder_to_move_into)
     expect(folder_to_move.parent.id).to eq(folder_to_move_into.id)
 
-    puts "delete folder"
+    puts 'delete folder'
     result = BOX_CLIENT.delete_folder(SUB_FOLDER_COPY, recursive: true)
     expect(result).to eq ({})
 
-    puts "inspect the trash"
+    puts 'inspect the trash'
     trash = BOX_CLIENT.trash()
     expect(trash).to be_a Array
 
-    puts "inspect trashed folder"
+    puts 'inspect trashed folder'
     trashed_folder = BOX_CLIENT.trashed_folder(SUB_FOLDER_COPY)
-    expect(trashed_folder.item_status).to eq("trashed")
+    expect(trashed_folder.item_status).to eq('trashed')
 
-    puts "restore trashed folder"
+    puts 'restore trashed folder'
     restored_folder = BOX_CLIENT.restore_trashed_folder(SUB_FOLDER_COPY)
-    expect(restored_folder.item_status).to eq("active")
+    expect(restored_folder.item_status).to eq('active')
 
-    puts "trash and permanently delete folder"
+    puts 'trash and permanently delete folder'
     BOX_CLIENT.delete_folder(SUB_FOLDER_COPY, recursive: true)
     result = BOX_CLIENT.delete_trashed_folder(SUB_FOLDER_COPY)
     expect(result).to eq({})
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes file operations"\"
-  it "invokes file operations" do
-    puts "upload a file"
+  # rake spec SPEC_OPTS="-e \"invokes file operations"\"
+  it 'invokes file operations' do
+    puts 'upload a file'
     new_file = BOX_CLIENT.upload_file("./spec/test_files/#{TEST_FILE_NAME}", @test_folder)
     expect(new_file.name).to eq(TEST_FILE_NAME)
     test_file = new_file
 
-    puts "upload a file with custom name"
+    puts 'upload a file with custom name'
     new_file = BOX_CLIENT.upload_file("./spec/test_files/#{TEST_FILE_NAME}", @test_folder, name: TEST_FILE_NAME_CUSTOM)
     expect(new_file.name).to eq(TEST_FILE_NAME_CUSTOM)
 
-    puts "get file using path"
+    puts 'get file using path'
     file = BOX_CLIENT.file_from_path("/#{TEST_FOLDER_NAME}/#{TEST_FILE_NAME}")
     expect(file.id).to eq(test_file.id)
 
-    puts "get file download url"
+    puts 'get file download url'
     download_url = BOX_CLIENT.download_url(test_file)
-    expect(download_url).to start_with("https://")
+    expect(download_url).to start_with('https://')
 
-    puts "get file info"
+    puts 'get file info'
     file_info = BOX_CLIENT.file(test_file)
     expect(file_info.id).to eq(test_file.id)
 
-    puts "get file preview link"
+    puts 'get file preview link'
     preview_url = BOX_CLIENT.preview_url(test_file)
-    expect(preview_url).to start_with("https://")
+    expect(preview_url).to start_with('https://')
 
-    puts "update file"
+    puts 'update file'
     new_description = 'this file is used to test Boxr'
-    tags = ['tag one','tag two']
+    tags = ['tag one', 'tag two']
     updated_file_info = BOX_CLIENT.update_file(test_file, description: new_description, tags: tags)
     expect(updated_file_info.description).to eq(new_description)
     tag_file_info = BOX_CLIENT.file(updated_file_info, fields: [:tags])
     expect(tag_file_info.tags.length).to eq(2)
 
-    puts "lock file"
-    expires_at_utc = Time.now.utc + (60*60*24) #one day from now
+    puts 'lock file'
+    expires_at_utc = Time.now.utc + (60 * 60 * 24) # one day from now
     locked_file = BOX_CLIENT.lock_file(test_file, expires_at: expires_at_utc, is_download_prevented: true)
     locked_file = BOX_CLIENT.file(locked_file, fields: [:lock])
     expect(locked_file.lock.type).to eq('lock')
     expect(locked_file.lock.expires_at).to_not be_nil
     expect(locked_file.lock.is_download_prevented).to eq(true)
 
-    puts "unlock file"
+    puts 'unlock file'
     unlocked_file = BOX_CLIENT.unlock_file(locked_file)
     unlocked_file = BOX_CLIENT.file(unlocked_file, fields: [:lock])
     expect(unlocked_file.lock).to be_nil
 
-    puts "download file"
+    puts 'download file'
     file = BOX_CLIENT.download_file(test_file)
     f = File.open("./spec/test_files/#{DOWNLOADED_TEST_FILE_NAME}", 'w+')
     f.write(file)
     f.close
-    expect(FileUtils.identical?("./spec/test_files/#{TEST_FILE_NAME}","./spec/test_files/#{DOWNLOADED_TEST_FILE_NAME}")).to eq(true)
+    expect(FileUtils.identical?("./spec/test_files/#{TEST_FILE_NAME}", "./spec/test_files/#{DOWNLOADED_TEST_FILE_NAME}")).to eq(true)
     File.delete("./spec/test_files/#{DOWNLOADED_TEST_FILE_NAME}")
 
-    puts "upload new version of file"
+    puts 'upload new version of file'
     new_version = BOX_CLIENT.upload_new_version_of_file("./spec/test_files/#{TEST_FILE_NAME}", test_file)
     expect(new_version.id).to eq(test_file.id)
 
-    puts "inspect versions of file"
+    puts 'inspect versions of file'
     versions = BOX_CLIENT.versions_of_file(test_file)
-    expect(versions.count).to eq(1) #the reason this is 1 instead of 2 is that Box considers 'versions' to be a versions other than 'current'
+    expect(versions.count).to eq(1) # the reason this is 1 instead of 2 is that Box considers 'versions' to be a versions other than 'current'
     v1 = versions.first
 
-    puts "promote old version of file"
+    puts 'promote old version of file'
     newer_version = BOX_CLIENT.promote_old_version_of_file(test_file, v1)
     versions = BOX_CLIENT.versions_of_file(test_file)
     expect(versions.count).to eq(2)
 
-    puts "delete old version of file"
-    result = BOX_CLIENT.delete_old_version_of_file(test_file,v1)
+    puts 'delete old version of file'
+    result = BOX_CLIENT.delete_old_version_of_file(test_file, v1)
     versions = BOX_CLIENT.versions_of_file(test_file)
-    expect(versions.count).to eq(2) #this is still 2 because with Box you can restore a trashed old version
+    expect(versions.count).to eq(2) # this is still 2 because with Box you can restore a trashed old version
 
-    puts "get file thumbnail"
+    puts 'get file thumbnail'
     thumb = BOX_CLIENT.thumbnail(test_file)
     expect(thumb).not_to be_nil
 
-    puts "create shared link for file"
+    puts 'create shared link for file'
     updated_file = BOX_CLIENT.create_shared_link_for_file(test_file, access: :open)
-    expect(updated_file.shared_link.access).to eq("open")
+    expect(updated_file.shared_link.access).to eq('open')
 
-    puts "disable shared link for file"
+    puts 'disable shared link for file'
     updated_file = BOX_CLIENT.disable_shared_link_for_file(test_file)
     expect(updated_file.shared_link).to be_nil
 
-    puts "copy file"
+    puts 'copy file'
     new_file_name = "copy of #{TEST_FILE_NAME}"
     new_file = BOX_CLIENT.copy_file(test_file, @test_folder, name: new_file_name)
     expect(new_file.name).to eq(new_file_name)
     NEW_FILE = new_file
 
-    puts "move file"
+    puts 'move file'
     new_folder = BOX_CLIENT.create_folder(SUB_FOLDER_NAME, @test_folder)
     test_file = BOX_CLIENT.move_file(test_file, new_folder.id)
     expect(test_file.parent.id).to eq(new_folder.id)
 
-    puts "delete file"
+    puts 'delete file'
     result = BOX_CLIENT.delete_file(NEW_FILE)
     expect(result).to eq({})
 
-    puts "get trashed file info"
+    puts 'get trashed file info'
     trashed_file = BOX_CLIENT.trashed_file(NEW_FILE)
-    expect(trashed_file.item_status).to eq("trashed")
+    expect(trashed_file.item_status).to eq('trashed')
 
-    puts "restore trashed file"
+    puts 'restore trashed file'
     restored_file = BOX_CLIENT.restore_trashed_file(NEW_FILE)
-    expect(restored_file.item_status).to eq("active")
+    expect(restored_file.item_status).to eq('active')
 
-    puts "trash and permanently delete file"
+    puts 'trash and permanently delete file'
     BOX_CLIENT.delete_file(NEW_FILE)
     result = BOX_CLIENT.delete_trashed_file(NEW_FILE)
     expect(result).to eq({})
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes web links operations"\"
+  # rake spec SPEC_OPTS="-e \"invokes web links operations"\"
   it 'invokes web links operations' do
-    puts "create web link"
-    web_link = BOX_CLIENT.create_web_link(TEST_WEB_URL, '0', name: "my new link", description: "link description...")
+    puts 'create web link'
+    web_link = BOX_CLIENT.create_web_link(TEST_WEB_URL, '0', name: 'my new link', description: 'link description...')
     expect(web_link.url).to eq(TEST_WEB_URL)
 
-    puts "get web link"
+    puts 'get web link'
     web_link_new = BOX_CLIENT.get_web_link(web_link)
     expect(web_link_new.id).to eq(web_link.id)
 
-    puts "update web link"
+    puts 'update web link'
     updated_web_link = BOX_CLIENT.update_web_link(web_link, name: 'new name', description: 'new description', url: TEST_WEB_URL2)
     expect(updated_web_link.url).to eq(TEST_WEB_URL2)
 
-    puts "delete web link"
+    puts 'delete web link'
     result = BOX_CLIENT.delete_web_link(web_link)
     expect(result).to eq({})
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes user operations"\"
-  it "invokes user operations" do
-    puts "inspect current user"
+  # rake spec SPEC_OPTS="-e \"invokes user operations"\"
+  it 'invokes user operations' do
+    puts 'inspect current user'
     user = BOX_CLIENT.current_user
     expect(user.status).to eq('active')
     user = BOX_CLIENT.me(fields: [:role])
     expect(user.role).to_not be_nil
 
-    puts "inspect a user"
+    puts 'inspect a user'
     user = BOX_CLIENT.user(@test_user)
     expect(user.id).to eq(@test_user.id)
 
-    puts "inspect all users"
+    puts 'inspect all users'
     all_users = BOX_CLIENT.all_users()
-    test_user = all_users.find{|u| u.id == @test_user.id}
+    test_user = all_users.find { |u| u.id == @test_user.id }
     expect(test_user).to_not be_nil
 
-    #create user is tested in the before method
+    # create user is tested in the before method
 
-    puts "update user"
-    new_name = "Chuck Nevitt"
+    puts 'update user'
+    new_name = 'Chuck Nevitt'
     user = BOX_CLIENT.update_user(@test_user, name: new_name)
     expect(user.name).to eq(new_name)
 
-    puts "add email alias for user"
-    email_alias = "test-boxr-user-alias@boxntest.com" #{('a'..'z').to_a.shuffle[0,10].join}.com"
+    puts 'add email alias for user'
+    email_alias = 'test-boxr-user-alias@boxntest.com' # {('a'..'z').to_a.shuffle[0,10].join}.com"
     new_alias = BOX_CLIENT.add_email_alias_for_user(@test_user, email_alias)
     expect(new_alias.type).to eq('email_alias')
 
-    puts "get email aliases for user"
+    puts 'get email aliases for user'
     email_aliases = BOX_CLIENT.email_aliases_for_user(@test_user)
     expect(email_aliases.first.id).to eq(new_alias.id)
 
-    puts "remove email alias for user"
+    puts 'remove email alias for user'
     result = BOX_CLIENT.remove_email_alias_for_user(@test_user, new_alias.id)
     expect(result).to eq({})
 
-    puts "delete user"
+    puts 'delete user'
     result = BOX_CLIENT.delete_user(@test_user, force: true)
     expect(result).to eq({})
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes group operations"\"
-  it "invokes group operations" do
-    puts "create group"
+  # rake spec SPEC_OPTS="-e \"invokes group operations"\"
+  it 'invokes group operations' do
+    puts 'create group'
     group = BOX_CLIENT.create_group(TEST_GROUP_NAME)
     expect(group.name).to eq(TEST_GROUP_NAME)
 
-    puts "inspect groups"
+    puts 'inspect groups'
     groups = BOX_CLIENT.groups
-    test_group = groups.find{|g| g.name == TEST_GROUP_NAME}
+    test_group = groups.find { |g| g.name == TEST_GROUP_NAME }
     expect(test_group).to_not be_nil
 
-    puts "update group"
-    new_name = "Test Boxr Group Renamed"
+    puts 'update group'
+    new_name = 'Test Boxr Group Renamed'
     group = BOX_CLIENT.update_group(test_group, new_name)
     expect(group.name).to eq(new_name)
-    group = BOX_CLIENT.rename_group(test_group,TEST_GROUP_NAME)
+    group = BOX_CLIENT.rename_group(test_group, TEST_GROUP_NAME)
     expect(group.name).to eq(TEST_GROUP_NAME)
 
-    puts "add user to group"
+    puts 'add user to group'
     group_membership = BOX_CLIENT.add_user_to_group(@test_user, test_group)
     expect(group_membership.user.id).to eq(@test_user.id)
     expect(group_membership.group.id).to eq(test_group.id)
     membership = group_membership
 
-    puts "inspect group membership"
+    puts 'inspect group membership'
     group_membership = BOX_CLIENT.group_membership(membership)
     expect(group_membership.id).to eq(membership.id)
 
-    puts "inspect group memberships"
+    puts 'inspect group memberships'
     group_memberships = BOX_CLIENT.group_memberships(test_group)
     expect(group_memberships.count).to eq(1)
     expect(group_memberships.first.id).to eq(membership.id)
 
-    puts "inspect group memberships for a user"
+    puts 'inspect group memberships for a user'
     group_memberships = BOX_CLIENT.group_memberships_for_user(@test_user)
     expect(group_memberships.count).to eq(1)
     expect(group_memberships.first.id).to eq(membership.id)
 
-    puts "inspect group memberships for me"
-    #this is whatever user your developer token is tied to
+    puts 'inspect group memberships for me'
+    # this is whatever user your developer token is tied to
     group_memberships = BOX_CLIENT.group_memberships_for_me
     expect(group_memberships).to be_a(Array)
 
-    puts "update group membership"
+    puts 'update group membership'
     group_membership = BOX_CLIENT.update_group_membership(membership, :admin)
-    expect(group_membership.role).to eq("admin")
+    expect(group_membership.role).to eq('admin')
 
-    puts "delete group membership"
+    puts 'delete group membership'
     result = BOX_CLIENT.delete_group_membership(membership)
     expect(result).to eq({})
     group_memberships = BOX_CLIENT.group_memberships_for_user(@test_user)
     expect(group_memberships.count).to eq(0)
 
-    puts "inspect group collaborations"
-    group_collaboration = BOX_CLIENT.add_collaboration(@test_folder, {id: test_group.id, type: :group}, :editor)
+    puts 'inspect group collaborations'
+    group_collaboration = BOX_CLIENT.add_collaboration(@test_folder, { id: test_group.id, type: :group }, :editor)
     expect(group_collaboration.accessible_by.id).to eq(test_group.id)
 
-    puts "delete group"
+    puts 'delete group'
     response = BOX_CLIENT.delete_group(test_group)
     expect(response).to eq({})
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes comment operations"\"
-  it "invokes comment operations" do
+  # rake spec SPEC_OPTS="-e \"invokes comment operations"\"
+  it 'invokes comment operations' do
     new_file = BOX_CLIENT.upload_file("./spec/test_files/#{TEST_FILE_NAME}", @test_folder)
     test_file = new_file
 
-    puts "add comment to file"
+    puts 'add comment to file'
     comment = BOX_CLIENT.add_comment_to_file(test_file, message: COMMENT_MESSAGE)
     expect(comment.message).to eq(COMMENT_MESSAGE)
     COMMENT = comment
 
-    puts "reply to comment"
+    puts 'reply to comment'
     reply = BOX_CLIENT.reply_to_comment(COMMENT, message: REPLY_MESSAGE)
     expect(reply.message).to eq(REPLY_MESSAGE)
 
-    puts "get file comments"
+    puts 'get file comments'
     comments = BOX_CLIENT.file_comments(test_file)
     expect(comments.count).to eq(2)
 
-    puts "update a comment"
+    puts 'update a comment'
     comment = BOX_CLIENT.change_comment(COMMENT, CHANGED_COMMENT_MESSAGE)
     expect(comment.message).to eq(CHANGED_COMMENT_MESSAGE)
 
-    puts "get comment info"
+    puts 'get comment info'
     comment = BOX_CLIENT.comment(COMMENT)
     expect(comment.id).to eq(COMMENT.id)
 
-    puts "delete comment"
+    puts 'delete comment'
     result = BOX_CLIENT.delete_comment(COMMENT)
     expect(result).to eq({})
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes collaborations operations"\"
-  it "invokes collaborations operations" do
-    puts "add collaboration"
-    collaboration = BOX_CLIENT.add_collaboration(@test_folder, {id: @test_user.id, type: :user}, :viewer_uploader)
+  # rake spec SPEC_OPTS="-e \"invokes collaborations operations"\"
+  it 'invokes collaborations operations' do
+    puts 'add collaboration'
+    collaboration = BOX_CLIENT.add_collaboration(@test_folder, { id: @test_user.id, type: :user }, :viewer_uploader)
     expect(collaboration.accessible_by.id).to eq(@test_user.id)
     COLLABORATION = collaboration
 
-    puts "inspect collaboration"
+    puts 'inspect collaboration'
     collaboration = BOX_CLIENT.collaboration(COLLABORATION)
     expect(collaboration.id).to eq(COLLABORATION.id)
 
-    puts "edit collaboration"
-    collaboration = BOX_CLIENT.edit_collaboration(COLLABORATION, role: "viewer uploader")
-    expect(collaboration.role).to eq("viewer uploader")
+    puts 'edit collaboration'
+    collaboration = BOX_CLIENT.edit_collaboration(COLLABORATION, role: 'viewer uploader')
+    expect(collaboration.role).to eq('viewer uploader')
 
-    puts "inspect folder collaborations"
+    puts 'inspect folder collaborations'
     collaborations = BOX_CLIENT.folder_collaborations(@test_folder)
     expect(collaborations.count).to eq(1)
     expect(collaborations[0].id).to eq(COLLABORATION.id)
 
-    puts "remove collaboration"
+    puts 'remove collaboration'
     result = BOX_CLIENT.remove_collaboration(COLLABORATION)
     expect(result).to eq({})
     collaborations = BOX_CLIENT.folder_collaborations(@test_folder)
     expect(collaborations.count).to eq(0)
 
-    puts "inspect pending collaborations"
+    puts 'inspect pending collaborations'
     pending_collaborations = BOX_CLIENT.pending_collaborations
     expect(pending_collaborations).to eq([])
 
-    puts "add invalid collaboration"
-    expect { BOX_CLIENT.add_collaboration(@test_folder, {id: @test_user.id, type: :user}, :invalid_role)}.to raise_error
+    puts 'add invalid collaboration'
+    expect { BOX_CLIENT.add_collaboration(@test_folder, { id: @test_user.id, type: :user }, :invalid_role) }.to raise_error
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes task operations"\"
-  it "invokes task operations" do
+  # rake spec SPEC_OPTS="-e \"invokes task operations"\"
+  it 'invokes task operations' do
     test_file = BOX_CLIENT.upload_file("./spec/test_files/#{TEST_FILE_NAME}", @test_folder)
-    collaboration = BOX_CLIENT.add_collaboration(@test_folder, {id: @test_user.id, type: :user}, :editor)
 
-    puts "create task"
+    puts 'create task'
     new_task = BOX_CLIENT.create_task(test_file, message: TEST_TASK_MESSAGE)
     expect(new_task.message).to eq(TEST_TASK_MESSAGE)
     TEST_TASK = new_task
 
-    puts "inspect file tasks"
+    puts 'inspect file tasks'
     tasks = BOX_CLIENT.file_tasks(test_file)
     expect(tasks.first.id).to eq(TEST_TASK.id)
 
-    puts "inspect task"
+    puts 'inspect task'
     task = BOX_CLIENT.task(TEST_TASK)
     expect(task.id).to eq(TEST_TASK.id)
 
-    puts "update task"
-    NEW_TASK_MESSAGE = "new task message"
+    puts 'update task'
+    NEW_TASK_MESSAGE = 'new task message'.freeze
     updated_task = BOX_CLIENT.update_task(TEST_TASK, message: NEW_TASK_MESSAGE)
     expect(updated_task.message).to eq(NEW_TASK_MESSAGE)
 
-    puts "create task assignment"
+    puts 'create task assignment'
     task_assignment = BOX_CLIENT.create_task_assignment(TEST_TASK, assign_to: @test_user.id)
     expect(task_assignment.assigned_to.id).to eq(@test_user.id)
     TASK_ASSIGNMENT = task_assignment
 
-    puts "inspect task assignment"
+    puts 'inspect task assignment'
     task_assignment = BOX_CLIENT.task_assignment(TASK_ASSIGNMENT)
     expect(task_assignment.id).to eq(TASK_ASSIGNMENT.id)
 
-    puts "inspect task assignments"
+    puts 'inspect task assignments'
     task_assignments = BOX_CLIENT.task_assignments(TEST_TASK)
     expect(task_assignments.count).to eq(1)
     expect(task_assignments[0].id).to eq(TASK_ASSIGNMENT.id)
 
-    #TODO: can't do this test yet because the test user needs to confirm their email address before you can do this
-    puts "update task assignment"
-    expect {
-              box_client_as_test_user = Boxr::Client.new(ENV['BOX_DEVELOPER_TOKEN'], as_user_id: @test_user.id)
-              new_message = "Updated task message"
-              task_assignment = box_client_as_test_user.update_task_assignment(TEST_TASK, resolution_state: :completed)
-              expect(task_assignment.resolution_state).to eq('completed')
-            }.to raise_error
+    # TODO: can't do this test yet because the test user needs to confirm their
+    # email address before you can do this
+    puts 'update task assignment'
+    expect do
+      box_client_as_test_user = Boxr::Client.new(ENV['BOX_DEVELOPER_TOKEN'], as_user_id: @test_user.id)
+      task_assignment = box_client_as_test_user.update_task_assignment(TEST_TASK, resolution_state: :completed)
+      expect(task_assignment.resolution_state).to eq('completed')
+    end.to raise_error
 
-    puts "delete task assignment"
+    puts 'delete task assignment'
     result = BOX_CLIENT.delete_task_assignment(TASK_ASSIGNMENT)
     expect(result).to eq({})
 
-    puts "delete task"
+    puts 'delete task'
     result = BOX_CLIENT.delete_task(TEST_TASK)
     expect(result).to eq({})
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes file metadata operations"\"
-  it "invokes file metadata operations" do
+  # rake spec SPEC_OPTS="-e \"invokes file metadata operations"\"
+  it 'invokes file metadata operations' do
     test_file = BOX_CLIENT.upload_file("./spec/test_files/#{TEST_FILE_NAME}", @test_folder)
 
-    puts "create metadata"
-    meta = {"a" => "hello", "b" => "world"}
+    puts 'create metadata'
+    meta = { 'a' => 'hello', 'b' => 'world' }
     metadata = BOX_CLIENT.create_metadata(test_file, meta)
-    expect(metadata.a).to eq("hello")
+    expect(metadata.a).to eq('hello')
 
-    puts "update metadata"
-    metadata = BOX_CLIENT.update_metadata(test_file, {op: :replace, path: "/b", value: "there"})
-    expect(metadata.b).to eq("there")
-    metadata = BOX_CLIENT.update_metadata(test_file, [{op: :replace, path: "/b", value: "friend"}])
-    expect(metadata.b).to eq("friend")
+    puts 'update metadata'
+    metadata = BOX_CLIENT.update_metadata(test_file, op: :replace, path: '/b', value: 'there')
+    expect(metadata.b).to eq('there')
+    metadata = BOX_CLIENT.update_metadata(test_file, [{ op: :replace, path: '/b', value: 'friend' }])
+    expect(metadata.b).to eq('friend')
 
-    puts "get metadata"
+    puts 'get metadata'
     metadata = BOX_CLIENT.metadata(test_file)
-    expect(metadata.a).to eq("hello")
+    expect(metadata.a).to eq('hello')
 
-    puts "delete metadata"
+    puts 'delete metadata'
     result = BOX_CLIENT.delete_metadata(test_file)
     expect(result).to eq({})
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes folder metadata operations"\"
-  #NOTE: this test will fail unless you create a metadata template called 'test' with two attributes: 'a' of type text, and 'b' of type text
-  it "invokes folder metadata operations" do
+  # rake spec SPEC_OPTS="-e \"invokes folder metadata operations"\"
+  # NOTE: this test will fail unless you create a metadata template called 'test' with two attributes: 'a' of type text, and 'b' of type text
+  it 'invokes folder metadata operations' do
     new_folder = BOX_CLIENT.create_folder(SUB_FOLDER_NAME, @test_folder)
 
-    puts "create folder metadata"
-    meta = {"a" => "hello", "b" => "world"}
-    metadata = BOX_CLIENT.create_folder_metadata(new_folder, meta, "enterprise", "test")
-    expect(metadata.a).to eq("hello")
+    puts 'create folder metadata'
+    meta = { 'a' => 'hello', 'b' => 'world' }
+    metadata = BOX_CLIENT.create_folder_metadata(new_folder, meta, 'enterprise', 'test')
+    expect(metadata.a).to eq('hello')
 
-    puts "update folder metadata"
-    metadata = BOX_CLIENT.update_folder_metadata(new_folder, {op: :replace, path: "/b", value: "there"}, "enterprise", "test")
-    expect(metadata.b).to eq("there")
-    metadata = BOX_CLIENT.update_folder_metadata(new_folder, [{op: :replace, path: "/b", value: "friend"}], "enterprise", "test")
-    expect(metadata.b).to eq("friend")
+    puts 'update folder metadata'
+    metadata = BOX_CLIENT.update_folder_metadata(new_folder, { op: :replace, path: '/b', value: 'there' }, 'enterprise', 'test')
+    expect(metadata.b).to eq('there')
+    metadata = BOX_CLIENT.update_folder_metadata(new_folder, [{ op: :replace, path: '/b', value: 'friend' }], 'enterprise', 'test')
+    expect(metadata.b).to eq('friend')
 
-    puts "get folder metadata"
-    metadata = BOX_CLIENT.folder_metadata(new_folder, "enterprise", "test")
-    expect(metadata.a).to eq("hello")
+    puts 'get folder metadata'
+    metadata = BOX_CLIENT.folder_metadata(new_folder, 'enterprise', 'test')
+    expect(metadata.a).to eq('hello')
 
-    puts "delete folder metadata"
-    result = BOX_CLIENT.delete_folder_metadata(new_folder, "enterprise", "test")
+    puts 'delete folder metadata'
+    result = BOX_CLIENT.delete_folder_metadata(new_folder, 'enterprise', 'test')
     expect(result).to eq({})
   end
 
-  #rake spec SPEC_OPTS="-e \"invokes search operations"\"
-  it "invokes search operations" do
-    #the issue with this test is that Box can take between 5-10 minutes to index any content uploaded; this is just a smoke test
-    #so we are searching for something that should return zero results
-    puts "perform search"
-    results = BOX_CLIENT.search("sdlfjuwnsljsdfuqpoiqweouyvnnadsfkjhiuweruywerbjvhvkjlnasoifyukhenlwdflnsdvoiuawfydfjh")
+  # rake spec SPEC_OPTS="-e \"invokes search operations"\"
+  it 'invokes search operations' do
+    # the issue with this test is that Box can take between 5-10 minutes to
+    # index any content uploaded; this is just a smoke test so we are searching
+    # for something that should return zero results
+    puts 'perform search'
+    results = BOX_CLIENT.search('sdlfjuwnsljsdfuqpoiqweouyvnnadsfkjhiuweruywerbjvhvkjlnasoifyukhenlwdflnsdvoiuawfydfjh')
     expect(results).to eq([])
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
-require 'dotenv'; Dotenv.load
-require 'simplecov'; SimpleCov.start
+require 'dotenv'
+Dotenv.load
+require 'simplecov'
+SimpleCov.start
 require 'boxr'
 require 'awesome_print'


### PR DESCRIPTION
Following conventions of rubocop and best practice, this is a general cleanup but not really overall refactor of the code. Line length has been reduced in places when available with little effort or code modification. Predicate methods have been used to be more Ruby like when better practice. Single quotes instead of double quotes in relevant places to avoid potential interpolation. Useless variable assignments removed. Unused variables declared to avoid doing array shifts marked with _ to know they're ignored. Guard statements added for better clarity of overly complex conditionals. Some looping codes were changed more because of the manner in which they were written being less efficient.
