### PR TITLE
Add call to create metadata templates

### DIFF
--- a/lib/boxr/metadata.rb
+++ b/lib/boxr/metadata.rb
@@ -98,5 +98,12 @@ module Boxr
       metadata, response = post(uri, schema, content_type: "application/json")
       metadata
     end
+
+    def update_metadata(scope, templateKey, operations: [])
+      uri = "#{METADATA_TEMPLATES_URI}/#{scope}/#{template_key}/schema"
+
+      metadata, response = put(uri, operations, content_type: "application/json")
+      metadata
+    end
   end
 end

--- a/lib/boxr/metadata.rb
+++ b/lib/boxr/metadata.rb
@@ -84,5 +84,19 @@ module Boxr
       schema
     end
 
+    def create_metadata_template(scope, templateKey, displayName, fields: [], hidden: nil)
+      uri = "#{METADATA_TEMPLATES_URI}/schema"
+      schema = {
+        templateKey: templateKey,
+        scope: scope,
+        displayName: displayName,
+        fields: fields
+      }
+      
+      schema[:hidden] = hidden unless hidden.nil?
+
+      metadata, response = post(uri, schema, content_type: "application/json")
+      metadata
+    end
   end
 end


### PR DESCRIPTION
[Work in Progress]

This adds actions to use the [Metadata Template APIs](https://docs.box.com/reference#create-metadata-schema). 
