### PR TITLE
Fixes README documentation for create_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ alias :user :user_from_id
 
 all_users(filter_term: nil, fields: [], offset: 0, limit: DEFAULT_LIMIT)
 
-create_user(login, name, role: nil, language: nil, is_sync_enabled: nil, job_title: nil,
+create_user(name, login: nil, role: nil, language: nil, is_sync_enabled: nil, job_title: nil,
             phone: nil, address: nil, space_amount: nil, tracking_codes: nil,
             can_see_managed_users: nil, is_external_collab_restricted: nil, status: nil, timezone: nil,
             is_exempt_from_device_limits: nil, is_exempt_from_login_verification: nil)


### PR DESCRIPTION
The `create_user` method signature in `lib/boxr/users.rb` doesn't match what is documented in the README. This updates the README to match the method signature.