### PR TITLE
Removed duplicated word from ReadMe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ puts "Shared Link: #{updated_file.shared_link.url}"
 ```
 
 ### NOTE: Using HTTP mocking libraries for testing
-When using HTTP mocking libraries for testing, you may need to set Boxr::BOX_CLIENT to a fresh instance of HTTPClient in your test setup after loading the HTTP mocking library. For example, when using WebMock with RSpec you might could add the following to your RSpec configuration:
+When using HTTP mocking libraries for testing, you may need to set Boxr::BOX_CLIENT to a fresh instance of HTTPClient in your test setup after loading the HTTP mocking library. For example, when using WebMock with RSpec you might add the following to your RSpec configuration:
 ``` ruby
 RSpec.configure do |config|
   config.before(:suite) do


### PR DESCRIPTION
## Problem 
In the following sentence, there are two words used for the same meaning. 'For example, when using WebMock with RSpec you **might could** add the following to your RSpec configuration'

## Solution
Removed "could" 