### PR TITLE
Allow updating name and file type via the new version method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Boxr
-Boxr is a Ruby client library for the Box V2 Content API.  Box employees affectionately refer to one another as Boxers, hence the name of this gem.  
+Boxr is a Ruby client library for the Box V2 Content API.  Box employees affectionately refer to one another as Boxers, hence the name of this gem.
 
 The purpose of this gem is to provide a clear, efficient, and intentional method of interacting with the Box Content API. As with any SDK that wraps a REST API, it is important to fully understand the Box Content API at the REST endpoint level.  You are strongly encouraged to read through the Box documentation located [here](https://box-content.readme.io/).
 
 The full RubyDocs for Boxr can be found [here](http://www.rubydoc.info/gems/boxr/Boxr/Client).  You are also encouraged to rely heavily on the source code found in the [lib/boxr](https://github.com/cburnette/boxr/tree/master/lib/boxr) directory of this gem, as well as on the integration tests found [here](https://github.com/cburnette/boxr/blob/master/spec/boxr_spec.rb).
+
+## Versioning
+
+Boxr follows Semantic Versioning since version 1.5.0
 
 ## Requirements
 This gem requires Ruby 2.0.0 or higher.  The integration tests are currently being run using MRI Ruby 2.0.0-p643 and MRI Ruby 2.2.0.

--- a/lib/boxr/files.rb
+++ b/lib/boxr/files.rb
@@ -128,8 +128,8 @@ module Boxr
       file_info.entries[0]
     end
 
-    def upload_new_version_of_file(path_to_file, file, name: nil, content_modified_at: nil, send_content_md5: true,
-                                    preflight_check: true, if_match: nil)
+    def upload_new_version_of_file(path_to_file, file, content_modified_at: nil, send_content_md5: true,
+                                    preflight_check: true, if_match: nil, name: nil)
       filename = name ? name : File.basename(path_to_file)
 
       file_id = ensure_id(file)

--- a/lib/boxr/files.rb
+++ b/lib/boxr/files.rb
@@ -128,8 +128,10 @@ module Boxr
       file_info.entries[0]
     end
 
-    def upload_new_version_of_file(path_to_file, file, content_modified_at: nil, send_content_md5: true,
+    def upload_new_version_of_file(path_to_file, file, name: nil, content_modified_at: nil, send_content_md5: true,
                                     preflight_check: true, if_match: nil)
+      filename = name ? name : File.basename(path_to_file)
+
       file_id = ensure_id(file)
       preflight_check_new_version_of_file(path_to_file, file_id) if preflight_check
 
@@ -139,9 +141,10 @@ module Boxr
 
       File.open(path_to_file) do |file|
         content_md5 = send_content_md5 ? Digest::SHA1.file(file).hexdigest : nil
-        attributes = {filename: file}
+        attributes = {name: filename}
         attributes[:content_modified_at] = content_modified_at.to_datetime.rfc3339 unless content_modified_at.nil?
-        file_info, response = post(uri, attributes, process_body: false, content_md5: content_md5, if_match: if_match)
+        body = {attributes: JSON.dump(attributes), file: file}
+        file_info, response = post(uri, body, process_body: false, content_md5: content_md5, if_match: if_match)
       end
 
       file_info.entries[0]

--- a/lib/boxr/version.rb
+++ b/lib/boxr/version.rb
@@ -1,3 +1,3 @@
 module Boxr
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end

--- a/lib/boxr/version.rb
+++ b/lib/boxr/version.rb
@@ -1,3 +1,3 @@
 module Boxr
-  VERSION = "1.4.1"
+  VERSION = "1.5.0"
 end


### PR DESCRIPTION
Currently, it is impossible to update a filename / type with the `upload_new_version_of_file` method of Boxr.

In our case, we allow transformations of PDF/PNG/etc which are then converted into a standard format. So when we save a new version, we want to supply a file name/extension.

I imitated the updates made to the regular `upload_file` method to allow optional naming, and to properly build the attributes + body using the file's base name.

@cburnette Please review and merge if possible!