### PR TITLE
Remove monkey patch on Enumerable

### DIFF
--- a/lib/boxr.rb
+++ b/lib/boxr.rb
@@ -24,17 +24,24 @@ require 'boxr/auth'
 require 'boxr/web_links'
 require 'boxr/watermarking'
 
-module Enumerable
+class BoxrCollection < Array
   def files
-    self.select{|i| i.type == 'file'}
+    collection_for_type('file')
   end
 
   def folders
-    self.select{|i| i.type == 'folder'}
+    collection_for_type('folder')
   end
 
   def web_links
-    self.select{|i| i.type == 'web_link'}
+    collection_for_type('web_link')
+  end
+
+  private
+
+  def collection_for_type(type)
+    items = select { |i| i.type == type }
+    BoxrCollection.new(items)
   end
 end
 

--- a/lib/boxr/client.rb
+++ b/lib/boxr/client.rb
@@ -133,7 +133,7 @@ module Boxr
         end
       end until offset - total_count >= 0
 
-      entries.flatten.map{|i| BoxrMash.new(i)}
+      BoxrCollection.new(entries.flatten.map{ |i| BoxrMash.new(i) })
     end
 
     def post(uri, body, query: nil, success_codes: [201], process_body: true, content_md5: nil, content_type: nil, if_match: nil)

--- a/lib/boxr/version.rb
+++ b/lib/boxr/version.rb
@@ -1,3 +1,3 @@
 module Boxr
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end


### PR DESCRIPTION
Thanks for your work on this gem! I have a small PR which removes the monkey-patch on Enumerable 🐒 

## The issue
We use this gem in one of our Rails apps, and noticed that this gem was overriding some of the scopes on our models. Consider the following ActiveRecord model:

```ruby
class Attachment < ActiveRecord::Base
  scope :files, -> { where(attachment_type: :file) }
  scope :folders, -> { where(attachment_type: :folders) }
end
```

`ActiveRecord::Relation` includes `Enumerable`, so when you retrieve a collection of records from the database, you will not be able to call the scopes named `files` or `folders`, because the methods in the `boxr` gem will be found first:

```ruby
pry(main)> Attachment.all.method(:folders).source_location
=> ["/Users/alextaylor/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/boxr-1.4.0/lib/boxr.rb", 32]
```

## The fix

Instead of monkey-patching Enumerable to get some methods we want on to arrays, we can instantiate our own `BoxrCollection` object which behaves like an Array. This is preferrable to monkey-patching because we're not polluting the namespace of other objects in our app which might use the Enumerable module.