### PR TITLE
Change parameters in create_user example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,10 +298,12 @@ alias :user :user_from_id
 
 all_users(filter_term: nil, fields: [], offset: 0, limit: DEFAULT_LIMIT)
 
-create_user(login, name, role: nil, language: nil, is_sync_enabled: nil, job_title: nil,
+
+create_user(name, login: nil, role: nil, language: nil, is_sync_enabled: nil, job_title: nil,
             phone: nil, address: nil, space_amount: nil, tracking_codes: nil,
             can_see_managed_users: nil, is_external_collab_restricted: nil, status: nil, timezone: nil,
-            is_exempt_from_device_limits: nil, is_exempt_from_login_verification: nil)
+            is_exempt_from_device_limits: nil, is_exempt_from_login_verification: nil,
+            is_platform_access_only: nil)
 
 
 update_user(user, notify: nil, enterprise: true, name: nil, role: nil, language: nil, is_sync_enabled: nil,


### PR DESCRIPTION
Adapt create_user example to the lib/boxr/users.rb method definition, so that name is the first parameter and the only required one.