### PR TITLE
Update dependency jwt version to `>= 1.4`

### DIFF
--- a/boxr.gemspec
+++ b/boxr.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "httpclient", "~> 2.8"
   spec.add_runtime_dependency "hashie", "~> 3.5"
   spec.add_runtime_dependency "addressable", "~> 2.3"
-  spec.add_runtime_dependency "jwt", "~> 1.4"
+  spec.add_runtime_dependency "jwt", ">= 1.4"
 end


### PR DESCRIPTION
Thanks for your work on this gem!

### Background
- Ruby gem `jwt` is a dependency gem of `boxr`.
- Boxr's gemspec file requires `jwt`'s version to be `~> 1.4`, which is equivalent to `['>= 1.4', '< 2.0']`.
- However, `jwt` has upgraded its version to a major version `2.X.X` since Feb 2017. See here: https://rubygems.org/gems/jwt
- There are many other gems using `jwt`'s newer versions.

**So there would be a dependency conflict if another gem in a ruby/rails app is using `jwt` with version larger than 2.**

### The change
This PR will change the dependency version of `jwt` from `~> 1.4` to `>= 1.4`.

### Is this safe?
Yes, it is safe.

Boxr is only using JWT's encode method:
```
JWT.encode(payload, private_key, "RS256", additional_headers)
```
^ https://github.com/cburnette/boxr/blob/master/lib/boxr/auth.rb#L78

JWT's encode method has not changed between 1.4 and 2.0 or higher. (I don't foresee JWT changing its `encode` method since this is a major interface method for JWT.)

Reference: JWT's doc: https://github.com/jwt/ruby-jwt#algorithms-and-usage