### PR TITLE
New method: Client#upload_file_from_io

### DIFF
--- a/lib/boxr/version.rb
+++ b/lib/boxr/version.rb
@@ -1,3 +1,3 @@
 module Boxr
-  VERSION = "1.10.1"
+  VERSION = "1.11.0"
 end

--- a/spec/boxr/files_spec.rb
+++ b/spec/boxr/files_spec.rb
@@ -12,6 +12,11 @@ describe "file operations" do
     new_file = BOX_CLIENT.upload_file("./spec/test_files/#{TEST_FILE_NAME}", @test_folder, name: TEST_FILE_NAME_CUSTOM)
     expect(new_file.name).to eq(TEST_FILE_NAME_CUSTOM)
 
+    puts "upload a file from IO"
+    io = File.open("./spec/test_files/#{TEST_FILE_NAME}")
+    new_file = BOX_CLIENT.upload_file_from_io(io, @test_folder, name: TEST_FILE_NAME_IO)
+    expect(new_file.name).to eq(TEST_FILE_NAME_IO)
+
     puts "get file using path"
     file = BOX_CLIENT.file_from_path("/#{TEST_FOLDER_NAME}/#{TEST_FILE_NAME}")
     expect(file.id).to eq(test_file.id)

--- a/spec/boxr_spec.rb
+++ b/spec/boxr_spec.rb
@@ -29,6 +29,7 @@ describe Boxr::Client do
   SUB_FOLDER_DESCRIPTION = 'This was created by the Boxr test suite'
   TEST_FILE_NAME = 'test file.txt'
   TEST_FILE_NAME_CUSTOM = 'test file custom.txt'
+  TEST_FILE_NAME_IO = 'test file io.txt'
   DOWNLOADED_TEST_FILE_NAME = 'downloaded test file.txt'
   COMMENT_MESSAGE = 'this is a comment'
   REPLY_MESSAGE = 'this is a comment reply'


### PR DESCRIPTION
This addresses #82 

This method allows users to upload a file from IO. This is useful if the file you want to upload is not 
read from disk, but for example from an HTTP request.

To have less code duplication, the existing upload_file method now uses the new upload_file_from_io method internally.