### PR TITLE
Hoist offset and limit options to methods for groups

### DIFF
--- a/lib/boxr/groups.rb
+++ b/lib/boxr/groups.rb
@@ -1,9 +1,9 @@
 module Boxr
   class Client
 
-    def groups(fields: [])
+    def groups(fields: [], offset: 0, limit: DEFAULT_LIMIT)
       query = build_fields_query(fields, GROUP_FIELDS_QUERY)
-      groups = get_all_with_pagination(GROUPS_URI, query: query, offset: 0, limit: DEFAULT_LIMIT)
+      groups = get_all_with_pagination(GROUPS_URI, query: query, offset: offset, limit: limit)
     end
 
     def group_from_id(group_id, fields: [])
@@ -39,21 +39,21 @@ module Boxr
       result
     end
 
-    def group_memberships(group)
+    def group_memberships(group, offset: 0, limit: DEFAULT_LIMIT)
       group_id = ensure_id(group)
       uri = "#{GROUPS_URI}/#{group_id}/memberships"
-      memberships = get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
+      memberships = get_all_with_pagination(uri, offset: offset, limit: limit)
     end
 
-    def group_memberships_for_user(user)
+    def group_memberships_for_user(user, offset: 0, limit: DEFAULT_LIMIT)
       user_id = ensure_id(user)
       uri = "#{USERS_URI}/#{user_id}/memberships"
-      memberships = get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
+      memberships = get_all_with_pagination(uri, offset: offset, limit: limit)
     end
 
-    def group_memberships_for_me
+    def group_memberships_for_me(offset: 0, limit: DEFAULT_LIMIT)
       uri = "#{USERS_URI}/me/memberships"
-      memberships = get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
+      memberships = get_all_with_pagination(uri, offset: offset, limit: limit)
     end
 
     def group_membership_from_id(membership_id)
@@ -89,10 +89,10 @@ module Boxr
       result
     end
 
-    def group_collaborations(group)
+    def group_collaborations(group, offset: 0, limit: DEFAULT_LIMIT)
       group_id = ensure_id(group)
       uri = "#{GROUPS_URI}/#{group_id}/collaborations"
-      collaborations = get_all_with_pagination(uri, offset: 0, limit: DEFAULT_LIMIT)
+      collaborations = get_all_with_pagination(uri, offset: offset, limit: limit)
     end
 
   end

--- a/lib/boxr/version.rb
+++ b/lib/boxr/version.rb
@@ -1,3 +1,3 @@
 module Boxr
-  VERSION = "1.11.0"
+  VERSION = "1.11.1"
 end


### PR DESCRIPTION
All of these methods are documented as having these options, but none of them actually have these options in reality. This corrects that.