### PR TITLE
Upgrade jwt/bundler to more modern dependencies.

### DIFF
--- a/boxr.gemspec
+++ b/boxr.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "simplecov", "~> 0.9"
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "httpclient", "~> 2.8"
   spec.add_runtime_dependency "hashie", "~> 3.5"
   spec.add_runtime_dependency "addressable", "~> 2.3"
-  spec.add_runtime_dependency "jwt", ">= 1.4"
+  spec.add_runtime_dependency "jwt", ">= 2.2"
 end


### PR DESCRIPTION
JWT 1.4 is four years old. The encode call seems to be the same between 1.4 and 2.2.

Locking to bundler 1.6 is also somewhat old and out of date.