### PR TITLE
Get file from parent and name

### DIFF
--- a/lib/boxr/files.rb
+++ b/lib/boxr/files.rb
@@ -26,6 +26,25 @@ module Boxr
     end
     alias :file :file_from_id
 
+    def file_from_parent_and_name(parent, name)
+      files = folder_items(parent, fields: [:id, :name]).files
+      file = files.find { |f| f.name == name }
+      file
+    end
+
+    def file_exists?(file_or_parent, name = nil)
+      file =
+        if name.nil?
+          file_from_id(file_or_parent, fields: [:id])
+        else
+          file_from_parent_and_name(file_or_parent, name)
+        end
+
+      !file.nil?
+    rescue BoxrError => error
+      error.status == 404 ? false : raise
+    end
+
     def embed_url(file, show_download: false, show_annotations: false)
       file_info = file_from_id(file, fields:[:expiring_embed_link])
       url = file_info.expiring_embed_link.url + "?showDownload=#{show_download}&showAnnotations=#{show_annotations}"

--- a/lib/boxr/files.rb
+++ b/lib/boxr/files.rb
@@ -12,7 +12,7 @@ module Boxr
       folder = folder_from_path(path_items.join('/'))
 
       files = folder_items(folder, fields: [:id, :name]).files
-      file = files.select{|f| f.name == file_name}.first
+      file = files.find { |f| f.name == file_name }
       raise BoxrError.new(boxr_message: "File not found: '#{file_name}'") if file.nil?
       file
     end

--- a/lib/boxr/folders.rb
+++ b/lib/boxr/folders.rb
@@ -10,7 +10,7 @@ module Boxr
 
       folder = path_folders.inject(Boxr::ROOT) do |parent_folder, folder_name|
         folders = folder_items(parent_folder, fields: [:id, :name]).folders
-        folder = folders.select{|f| f.name == folder_name}.first
+        folder = folders.find { |f| f.name == folder_name }
         raise BoxrError.new(boxr_message: "Folder not found: '#{folder_name}'") if folder.nil?
         folder
       end

--- a/spec/boxr/files_spec.rb
+++ b/spec/boxr/files_spec.rb
@@ -19,6 +19,16 @@ describe "file operations" do
     file = BOX_CLIENT.file_from_path("/#{TEST_FOLDER_NAME}/#{TEST_FILE_NAME}")
     expect(file.id).to eq(test_file.id)
 
+    puts "get file using parent and name"
+    file = BOX_CLIENT.file_from_parent_and_name(test_file.parent.id, TEST_FILE_NAME)
+    expect(file.id).to eq(test_file.id)
+
+    puts "test if file exists"
+    expect(BOX_CLIENT.file_exists?(test_file.id)).to be true
+    expect(BOX_CLIENT.file_exists?(test_file.parent.id, TEST_FILE_NAME)).to be true
+    expect(BOX_CLIENT.file_exists?(test_file.id + '-oops')).to be false
+    expect(BOX_CLIENT.file_exists?(test_file.parent.id, TEST_FILE_NAME + '-oops')).to be false
+
     puts "get file download url"
     download_url = BOX_CLIENT.download_url(test_file)
     expect(download_url).to start_with("https://")


### PR DESCRIPTION
Method `#file_from_parent_and_name` is useful because when one selects a folder using box's javascript content picker, it provides a folder object, not a path. I'm facing situations where I need to get the file object using a folder ID and a file name, hence I propose adding this method.

`#file_exists?` is more of a convenience.