### PR TITLE
Support trashed web links API

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,12 @@ get_web_link(web_link)
 update_web_link(web_link, url: nil, parent: nil, name: nil, description: nil)
 
 delete_web_link(web_link)
+
+trashed_web_link(web_link, fields: [])
+
+delete_trashed_web_link(web_link)
+
+restore_trashed_web_link(web_link, name: nil, parent: nil)
 ```
 #### [Comments](https://developer.box.com/en/reference/resources/comment/)
 ```ruby

--- a/lib/boxr/client.rb
+++ b/lib/boxr/client.rb
@@ -59,6 +59,10 @@ module Boxr
     GROUP_FIELDS = [:type, :id, :name, :created_at, :modified_at]
     GROUP_FIELDS_QUERY = GROUP_FIELDS.join(',')
 
+    WEB_LINK_FIELDS = [:type, :id, :created_at, :created_by, :description, :etag, :item_status, :modified_at, :modified_by,
+                       :name, :owned_by, :parent, :path_collection, :purged_at, :sequence_id, :shared_link, :trashed_at, :url]
+    WEB_LINK_FIELDS_QUERY = WEB_LINK_FIELDS.join(',')
+
     VALID_COLLABORATION_ROLES = ['editor','viewer','previewer','uploader','previewer uploader','viewer uploader','co-owner','owner']
 
 

--- a/lib/boxr/version.rb
+++ b/lib/boxr/version.rb
@@ -1,3 +1,3 @@
 module Boxr
-  VERSION = "1.15.0".freeze
+  VERSION = "1.16.0".freeze
 end

--- a/lib/boxr/web_links.rb
+++ b/lib/boxr/web_links.rb
@@ -61,6 +61,14 @@ module Boxr
     end
     alias :get_trashed_web_link :trashed_web_link
 
+    def restore_trashed_web_link(web_link, name: nil, parent: nil)
+      web_link_id = ensure_id(web_link)
+      parent_id = ensure_id(parent)
+
+      uri = "#{WEB_LINKS_URI}/#{web_link_id}"
+      restore_trashed_item(uri, name, parent_id)
+    end
+
     private
 
     def verify_url(item)

--- a/lib/boxr/web_links.rb
+++ b/lib/boxr/web_links.rb
@@ -51,6 +51,16 @@ module Boxr
       result
     end
 
+    def trashed_web_link(web_link, fields: [])
+      web_link_id = ensure_id(web_link)
+      uri = "#{WEB_LINKS_URI}/#{web_link_id}/trash"
+      query = build_fields_query(fields, WEB_LINK_FIELDS_QUERY)
+
+      web_link, response = get(uri, query: query)
+      web_link
+    end
+    alias :get_trashed_web_link :trashed_web_link
+
     private
 
     def verify_url(item)

--- a/lib/boxr/web_links.rb
+++ b/lib/boxr/web_links.rb
@@ -61,6 +61,13 @@ module Boxr
     end
     alias :get_trashed_web_link :trashed_web_link
 
+    def delete_trashed_web_link(web_link)
+      web_link_id = ensure_id(web_link)
+      uri = "#{WEB_LINKS_URI}/#{web_link_id}/trash"
+      result, response = delete(uri)
+      result
+    end
+
     def restore_trashed_web_link(web_link, name: nil, parent: nil)
       web_link_id = ensure_id(web_link)
       parent_id = ensure_id(parent)

--- a/spec/boxr/web_links_spec.rb
+++ b/spec/boxr/web_links_spec.rb
@@ -24,5 +24,10 @@ describe "web links operations" do
     puts "restore trashed web link"
     restored_web_link = BOX_CLIENT.restore_trashed_web_link(web_link)
     expect(restored_web_link.item_status).to eq("active")
+
+    puts "trash and permanently delete web link"
+    BOX_CLIENT.delete_web_link(web_link)
+    result = BOX_CLIENT.delete_trashed_web_link(web_link)
+    expect(result).to eq({})
   end
 end

--- a/spec/boxr/web_links_spec.rb
+++ b/spec/boxr/web_links_spec.rb
@@ -16,5 +16,9 @@ describe "web links operations" do
     puts "delete web link"
     result = BOX_CLIENT.delete_web_link(web_link)
     expect(result).to eq({})
+
+    puts "get trashed web link"
+    trashed_web_link = BOX_CLIENT.trashed_web_link(web_link)
+    expect(trashed_web_link.item_status).to eq("trashed")
   end
 end

--- a/spec/boxr/web_links_spec.rb
+++ b/spec/boxr/web_links_spec.rb
@@ -20,5 +20,9 @@ describe "web links operations" do
     puts "get trashed web link"
     trashed_web_link = BOX_CLIENT.trashed_web_link(web_link)
     expect(trashed_web_link.item_status).to eq("trashed")
+
+    puts "restore trashed web link"
+    restored_web_link = BOX_CLIENT.restore_trashed_web_link(web_link)
+    expect(restored_web_link.item_status).to eq("active")
   end
 end


### PR DESCRIPTION
Support trashed web links API

- [Get trashed web link](https://developer.box.com/reference/get-web-links-id-trash/)
  - 622fc6c
- [Restore web link](https://developer.box.com/reference/post-web-links-id/)
  - 829fa0d
- [Permanently remove web link](https://developer.box.com/reference/delete-web-links-id-trash/)
  - f9b86fe
