### PR TITLE
Add support for uploading new version from IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,16 @@ download_url(file, version: nil)
 upload_file(path_to_file, parent, content_created_at: nil, content_modified_at: nil,
             preflight_check: true, send_content_md5: true)
 
+upload_file_from_io(io, parent, name:, content_created_at: nil, content_modified_at: nil,
+                     preflight_check: true, send_content_md5: true)
+
 delete_file(file, if_match: nil)
 
 upload_new_version_of_file(path_to_file, file, content_modified_at: nil, send_content_md5: true,
                             preflight_check: true, if_match: nil)
+
+upload_new_version_of_file_from_io(io, file, name: nil, content_modified_at: nil, send_content_md5: true,
+                                    preflight_check: true, if_match: nil)
 
 versions_of_file(file)
 

--- a/lib/boxr/version.rb
+++ b/lib/boxr/version.rb
@@ -1,3 +1,3 @@
 module Boxr
-  VERSION = "1.16.0".freeze
+  VERSION = "1.17.0".freeze
 end

--- a/spec/boxr/files_spec.rb
+++ b/spec/boxr/files_spec.rb
@@ -67,20 +67,25 @@ describe "file operations" do
     new_version = BOX_CLIENT.upload_new_version_of_file("./spec/test_files/#{TEST_FILE_NAME}", test_file)
     expect(new_version.id).to eq(test_file.id)
 
+    puts "upload new version of file from IO"
+    io = File.open("./spec/test_files/#{TEST_FILE_NAME}")
+    new_version = BOX_CLIENT.upload_new_version_of_file_from_io(io, test_file)
+    expect(new_version.id).to eq(test_file.id)
+
     puts "inspect versions of file"
     versions = BOX_CLIENT.versions_of_file(test_file)
-    expect(versions.count).to eq(1) #the reason this is 1 instead of 2 is that Box considers 'versions' to be a versions other than 'current'
+    expect(versions.count).to eq(2) #the reason this is 2 instead of 3 is that Box considers 'versions' to be a versions other than 'current'
     v1 = versions.first
 
     puts "promote old version of file"
     newer_version = BOX_CLIENT.promote_old_version_of_file(test_file, v1)
     versions = BOX_CLIENT.versions_of_file(test_file)
-    expect(versions.count).to eq(2)
+    expect(versions.count).to eq(3)
 
     puts "delete old version of file"
     result = BOX_CLIENT.delete_old_version_of_file(test_file,v1)
     versions = BOX_CLIENT.versions_of_file(test_file)
-    expect(versions.count).to eq(2) #this is still 2 because with Box you can restore a trashed old version
+    expect(versions.count).to eq(3) #this is still 3 because with Box you can restore a trashed old version
 
     puts "get file thumbnail"
     thumb = BOX_CLIENT.thumbnail(test_file)


### PR DESCRIPTION
This commit adds support for uploading a new file version via IO instead of requiring a `file_path`.

```
upload_new_version_of_file_from_io(...)
```

I've modeled this after the `upload_file` and `upload_file_from_io` methods so the non-IO variant utilizes the new method. Of note, when adding tests I also needed to bump the version count being asserted on.