### PR TITLE
Update header access to standardized header names

### DIFF
--- a/lib/boxr/files.rb
+++ b/lib/boxr/files.rb
@@ -83,7 +83,7 @@ module Boxr
         body_json, response = get(uri, query: query, success_codes: [302,202], process_response: false, follow_redirect: false) #we don't want httpclient to automatically follow the redirect; we need to grab it
 
         if(response.status==302)
-          location = response.header['Location'][0]
+          location = (response.header['Location'] || response.header['location'])[0]
 
           if(follow_redirect)
             file_content, response = get(location, process_response: false)
@@ -92,8 +92,8 @@ module Boxr
             return location #simply return the url
           end
         elsif(response.status==202)
-          retry_after_seconds = response.header['Retry-After'][0]
-          sleep retry_after_seconds.to_i
+          retry_after_seconds = response.header['Retry-After'] || response.header['retry-after']
+          sleep retry_after_seconds[0].to_i
         end
       end until file_content
     end


### PR DESCRIPTION
## Problem being addressed
Box sent the following email info about header changes:
> We're reaching out to notify you of a change that may affect your Box application(s). On May 10th, 2021, as part of our continued infrastructure upgrade, Box's API response headers will standardize to always return as lowercase, in line with industry best practices and our API documentation. Applications that are using these headers, such as "location" and "retry-after", will need to verify that their applications are checking for these headers in a case-insensitive fashion. 

This PR addresses those changes in a backwards compatible way.

Note: I had issues running tests locally, and I wasn't clear where I should add tests for a change like this, but if you have recommendations, I'll gladly make changes! 👍 