### PR TITLE
Use `io.size` instead of `File.size` to accept StringIO

### DIFF
--- a/lib/boxr/files.rb
+++ b/lib/boxr/files.rb
@@ -272,7 +272,7 @@ module Boxr
     private
 
     def preflight_check(io, filename, parent_id)
-      size = File.size(io)
+      size = io.size
 
       #TODO: need to make sure that figuring out the filename from the path_to_file works for people using Windows
       attributes = {name: filename, parent: {id: "#{parent_id}"}, size: size}
@@ -280,7 +280,7 @@ module Boxr
     end
 
     def preflight_check_new_version_of_file(io, file_id)
-      size = File.size(io)
+      size = io.size
       attributes = {size: size}
       body_json, res = options("#{FILES_URI}/#{file_id}/content", attributes)
     end


### PR DESCRIPTION
Hi there! Thank you for create very useful gem.

I would upload from StringIO as well as File with `#upload_file_from_io` method.
Both File and StringIO have `#size` method to calculate file or buffer size.
If we accept IO interface, we will be able to upload StringIO as well as File.
- https://ruby-doc.org/core-2.7.0/File.html#method-i-size
- https://ruby-doc.org/stdlib-2.7.0/libdoc/stringio/rdoc/StringIO.html#method-i-size
