### PR TITLE
Update gemspec to exclude spec files

### DIFF
--- a/boxr.gemspec
+++ b/boxr.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/cburnette/boxr"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Currently these all get included in the gem itself, which makes the file size unnecessarily massive (mostly as a result of `spec/test_files/large test file.txt`). Bundler's newer boilerplate includes this updated bit excluding test/spec directories from the built gem, which should resolve the issue.

Normally I would say this isn't too big a deal, but in space-constrained environments (like AWS Lambda) 50MB can make a pretty big difference!