### PR TITLE
Allow chunked uploads to work with IO streams other than files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,10 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in boxr.gemspec
 gemspec
+
+gem "rake", "~> 10.0"
+gem "rspec", "~> 3.1"
+gem "simplecov", "~> 0.9"
+gem "dotenv", "~> 0.11"
+gem "awesome_print", "~> 1.8"
+gem "lru_redux", "~> 0.8"

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in boxr.gemspec
 gemspec
 
-gem "rake", "~> 10.0"
+gem "rake"
+gem "dotenv", "~> 2.0"
 gem "rspec", "~> 3.1"
 gem "simplecov", "~> 0.9"
-gem "dotenv", "~> 0.11"
 gem "awesome_print", "~> 1.8"
 gem "lru_redux", "~> 0.8"

--- a/boxr.gemspec
+++ b/boxr.gemspec
@@ -20,13 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0'
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "simplecov", "~> 0.9"
-  spec.add_development_dependency "dotenv", "~> 0.11"
-  spec.add_development_dependency "awesome_print", "~> 1.8"
-  spec.add_development_dependency "lru_redux", "~> 0.8"
   spec.add_development_dependency "parallel", "~> 1.0"
 
   spec.add_runtime_dependency "httpclient", "~> 2.8"

--- a/lib/boxr.rb
+++ b/lib/boxr.rb
@@ -4,6 +4,7 @@ require 'hashie'
 require 'addressable/template'
 require 'jwt'
 require 'securerandom'
+require 'stringio'
 
 require 'boxr/version'
 require 'boxr/errors'

--- a/spec/boxr/chunked_uploads_spec.rb
+++ b/spec/boxr/chunked_uploads_spec.rb
@@ -1,6 +1,9 @@
 #rake spec SPEC_OPTS="-e \"invokes chunked uploads operations"\"
+
+require "parallel"
+
 describe "chunked uploads operations" do
-  it "invokes chunked uploads operations" do
+  it "invokes chunked uploads session-related operations" do
     puts "create chunked upload session"
     new_session = BOX_CLIENT.chunked_upload_create_session_new_file("./spec/test_files/#{TEST_LARGE_FILE_NAME}", @test_folder)
     expect(new_session.id).not_to be_nil
@@ -16,14 +19,35 @@ describe "chunked uploads operations" do
     puts "abort chunked upload session"
     abort_info = BOX_CLIENT.chunked_upload_abort_session(new_session.id)
     expect(abort_info).to eq({})
-
-    puts "upload a large file in chunks"
-    new_file = BOX_CLIENT.chunked_upload_file("./spec/test_files/#{TEST_LARGE_FILE_NAME}", @test_folder)
-    expect(new_file.name).to eq(TEST_LARGE_FILE_NAME)
-    test_file = new_file
-
-    puts "upload new version of a large file in chunks"
-    new_version = BOX_CLIENT.chunked_upload_new_version_of_file("./spec/test_files/#{TEST_LARGE_FILE_NAME}", test_file)
-    expect(new_version.id).to eq(test_file.id)
   end
+
+  shared_examples "chunked uploads data-upload" do |n_threads:|
+    fit "uploads chunked uploads upload-related operations (threads: #{n_threads})" do
+        puts "upload a large file in chunks"
+        new_file = BOX_CLIENT.chunked_upload_file("./spec/test_files/#{TEST_LARGE_FILE_NAME}", @test_folder, n_threads: n_threads)
+        expect(new_file.name).to eq(TEST_LARGE_FILE_NAME)
+        test_file = new_file
+
+        puts "upload new version of a large file in chunks"
+        new_version = BOX_CLIENT.chunked_upload_new_version_of_file("./spec/test_files/#{TEST_LARGE_FILE_NAME}", test_file, n_threads: n_threads)
+        expect(new_version.id).to eq(test_file.id)
+
+        puts "upload a large file in chunks from IO stream"
+        filename = "yet another large file.txt"
+        io = StringIO.new
+        io << "1" * 21 * 1024**2
+        io.rewind
+        new_file = BOX_CLIENT.chunked_upload_file_from_io(io, @test_folder, filename, n_threads: n_threads)
+        expect(new_file.name).to eq(filename)
+        test_file = new_file
+
+        puts "upload new version of a large file in chunks from IO stream"
+        io.rewind
+        new_version = BOX_CLIENT.chunked_upload_new_version_of_file_from_io(io, test_file, filename, n_threads: n_threads)
+        expect(new_version.id).to eq(test_file.id)
+    end
+  end
+
+  it_behaves_like "chunked uploads data-upload", n_threads: 1
+  it_behaves_like "chunked uploads data-upload", n_threads: 2
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'boxr'
 require 'awesome_print'
 
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:each) do |test|
     if test.metadata[:skip_reset]
       puts "Skipping reset"
       next


### PR DESCRIPTION
I bumped into https://discuss.rubyonrails.org/t/transferring-files-from-s3-to-box-in-chunks-without-a-tmp-file/78841 - major coincidence :sweat_smile: - and just like reported in #106, chunked uploads aren't currently working for IO streams other than files. This PR fixes that, and I took the chance to do some small refactoring, extracting some methods out of `#chunked_upload_to_session_from_io`. 