### PR TITLE
Don't lock hashie to 3.5 version

### DIFF
--- a/boxr.gemspec
+++ b/boxr.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "parallel", "~> 1.0"
 
   spec.add_runtime_dependency "httpclient", "~> 2.8"
-  spec.add_runtime_dependency "hashie", "~> 3.5"
+  spec.add_runtime_dependency "hashie", ">= 3.5"
   spec.add_runtime_dependency "addressable", "~> 2.3"
   spec.add_runtime_dependency "jwt", ">= 1.4"
 end


### PR DESCRIPTION
Locking the version of hashie potentially causes conflicts with other gems that may rely on newer versions.