### PR TITLE
Fix fetching metadata in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,8 @@ require 'boxr'
 require 'awesome_print'
 
 RSpec.configure do |config|
-  config.before(:each) do
-    if test.metadata[:skip_reset]
+  config.before(:each) do |example|
+    if example.metadata[:skip_reset]
       puts "Skipping reset"
       next
     end


### PR DESCRIPTION
Specs can't be ran, they fail with an error 

```
Failure/Error: if test.metadata[:skip_reset]

ArgumentError:
  wrong number of arguments (given 0, expected 2..3)
# ./spec/spec_helper.rb:8:in `test'
# ./spec/spec_helper.rb:8:in `block (2 levels) in <top (required)>'
``` 

I'm not sure how it worked before but with this fix, metadata is fetching successfully. 