### PR TITLE
Add support for fetching annotations for a specific file

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ promote_old_version_of_file(file, file_version)
 
 delete_old_version_of_file(file, file_version, if_match: nil)
 
-copy_file(file, parent, name: nil)
+copy_file(file, parent, name: nil, version: nil)
 
 thumbnail(file, min_height: nil, min_width: nil, max_height: nil, max_width: nil)
 

--- a/lib/boxr/files.rb
+++ b/lib/boxr/files.rb
@@ -201,13 +201,15 @@ module Boxr
       result
     end
 
-    def copy_file(file, parent, name: nil)
+    def copy_file(file, parent, name: nil, version: nil)
       file_id = ensure_id(file)
       parent_id = ensure_id(parent)
+      version_id = ensure_id(version) unless version.nil?
 
       uri = "#{FILES_URI}/#{file_id}/copy"
       attributes = {:parent => {:id => parent_id}}
       attributes[:name] = name unless name.nil?
+      attributes[:version] = version_id unless version_id.nil?
       new_file, res = post(uri, attributes)
       new_file
     end


### PR DESCRIPTION
The Box API supports passing in the [ID of a file version](https://developer.box.com/reference/post-files-id-copy/#param-version) to copy. We have a need to ensure that if a file is being copied, the original (first) version is the one that is copied, no matter how many versions of the original there may be.

I used a kwarg because that's how `name` is handled, then added it to the attributes that are sent in the copy request only if an ID was provided.