### PR TITLE
add 202 as successful response

### DIFF
--- a/lib/boxr/client.rb
+++ b/lib/boxr/client.rb
@@ -143,7 +143,7 @@ module Boxr
       BoxrCollection.new(entries.flatten.map{ |i| BoxrMash.new(i) })
     end
 
-    def post(uri, body, query: nil, success_codes: [201], process_body: true, digest: nil, content_md5: nil, content_type: nil, if_match: nil, if_non_match: nil)
+    def post(uri, body, query: nil, success_codes: [201, 202], process_body: true, digest: nil, content_md5: nil, content_type: nil, if_match: nil, if_non_match: nil)
       uri = Addressable::URI.encode(uri)
       body = JSON.dump(body) if process_body
 


### PR DESCRIPTION
PR for this [issue](https://github.com/cburnette/boxr/issues/121) where [Box docs](https://developer.box.com/reference/post-files-upload-sessions-id-commit/#response) shows that it is possible to be returned a 202 during an upload session for chunked uploads. 

> [202](https://developer.box.com/reference/post-files-upload-sessions-id-commit/#param-202-undefined)
> Returns when all chunks have been uploaded but not yet processed.
> 
> Inspect the upload session to get more information about the progress of processing the chunks, then retry committing the file when all chunks have processed.