### PR TITLE
Add search param fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ shared_item(shared_link, shared_link_password: nil)
 ```
 #### [Search](https://developer.box.com/en/reference/get-search/)
 ```ruby
-search( query=nil, scope: nil, file_extensions: [],
+search( query=nil, scope: nil, file_extensions: [], fields: [],
         created_at_range_from_date: nil, created_at_range_to_date: nil,
         updated_at_range_from_date: nil, updated_at_range_to_date: nil,
         size_range_lower_bound_bytes: nil, size_range_upper_bound_bytes: nil,

--- a/lib/boxr/search.rb
+++ b/lib/boxr/search.rb
@@ -8,9 +8,11 @@ module Boxr
                size_range_lower_bound_bytes: nil, size_range_upper_bound_bytes: nil,
                owner_user_ids: [], ancestor_folder_ids: [], content_types: [], trash_content: nil,
                mdfilters: nil, type: nil, limit: 30, offset: 0)
-      if !mdfilters.nil? && !mdfilters.is_a?(String) # if a string is passed in assume it is already formatted correctly
+      # if a string is passed in assume it is already formatted correctly
+      if !mdfilters.nil? && !mdfilters.is_a?(String)
         unless mdfilters.is_a? Array
-          mdfilters = [mdfilters] # if just one mdfilter is specified ensure that it is packaged inside an array
+          # if just one mdfilter is specified ensure that it is packaged inside an array
+          mdfilters = [mdfilters]
         end
         mdfilters = JSON.dump(mdfilters)
       end

--- a/lib/boxr/search.rb
+++ b/lib/boxr/search.rb
@@ -2,7 +2,7 @@
 
 module Boxr
   class Client
-    def search(query = nil, scope: nil, file_extensions: [],
+    def search(query = nil, scope: nil, file_extensions: [], fields: [],
                created_at_range_from_date: nil, created_at_range_to_date: nil,
                updated_at_range_from_date: nil, updated_at_range_to_date: nil,
                size_range_lower_bound_bytes: nil, size_range_upper_bound_bytes: nil,
@@ -28,11 +28,13 @@ module Boxr
       owner_user_ids_string = to_comma_separated_string(owner_user_ids)
       ancestor_folder_ids_string = to_comma_separated_string(ancestor_folder_ids)
       content_types_string = to_comma_separated_string(content_types)
+      fields_string = to_comma_separated_string(fields)
 
       search_query = {}
       search_query[:query] = query unless query.nil?
       search_query[:scope] = scope unless scope.nil?
       search_query[:file_extensions] = file_extensions_string unless file_extensions_string.nil?
+      search_query[:fields] = fields_string unless fields_string.nil?
       search_query[:created_at_range] = created_at_range_string unless created_at_range_string.nil?
       search_query[:updated_at_range] = updated_at_range_string unless updated_at_range_string.nil?
       search_query[:size_range] = size_range_string unless size_range_string.nil?

--- a/spec/unit/search_spec.rb
+++ b/spec/unit/search_spec.rb
@@ -38,6 +38,7 @@ describe Boxr::Client do
         'test query',
         scope: 'user_content',
         file_extensions: %w[pdf doc],
+        fields: %w[id name type],
         created_at_range_from_date: from_date,
         created_at_range_to_date: to_date,
         updated_at_range_from_date: from_date,
@@ -61,6 +62,7 @@ describe Boxr::Client do
           query: 'test query',
           scope: 'user_content',
           file_extensions: 'pdf,doc',
+          fields: 'id,name,type',
           created_at_range: '2023-01-01T00:00:00+00:00,2023-12-31T00:00:00+00:00',
           updated_at_range: '2023-01-01T00:00:00+00:00,2023-12-31T00:00:00+00:00',
           size_range: '1024,1048576',
@@ -102,7 +104,8 @@ describe Boxr::Client do
         file_extensions: [],
         owner_user_ids: [],
         ancestor_folder_ids: [],
-        content_types: []
+        content_types: [],
+        fields: []
       )
 
       expect(result).to eq([test_file, test_folder])
@@ -118,7 +121,8 @@ describe Boxr::Client do
         file_extensions: ['pdf'],
         owner_user_ids: ['user1'],
         ancestor_folder_ids: ['folder1'],
-        content_types: ['name']
+        content_types: ['name'],
+        fields: ['id']
       )
 
       expect(result).to eq([test_file, test_folder])
@@ -130,6 +134,52 @@ describe Boxr::Client do
           owner_user_ids: 'user1',
           ancestor_folder_ids: 'folder1',
           content_types: 'name',
+          fields: 'id',
+          limit: 30,
+          offset: 0
+        }
+      )
+    end
+
+    it 'handles fields parameter with multiple values' do
+      result = client.search('test', fields: %w[id name type size])
+
+      expect(result).to eq([test_file, test_folder])
+      expect(client).to have_received(:get).with(
+        Boxr::Client::SEARCH_URI,
+        query: {
+          query: 'test',
+          fields: 'id,name,type,size',
+          limit: 30,
+          offset: 0
+        }
+      )
+    end
+
+    it 'handles fields parameter as string' do
+      result = client.search('test', fields: 'id,name,type')
+
+      expect(result).to eq([test_file, test_folder])
+      expect(client).to have_received(:get).with(
+        Boxr::Client::SEARCH_URI,
+        query: {
+          query: 'test',
+          fields: 'id,name,type',
+          limit: 30,
+          offset: 0
+        }
+      )
+    end
+
+    it 'handles fields parameter as symbol' do
+      result = client.search('test', fields: :id)
+
+      expect(result).to eq([test_file, test_folder])
+      expect(client).to have_received(:get).with(
+        Boxr::Client::SEARCH_URI,
+        query: {
+          query: 'test',
+          fields: :id,
           limit: 30,
           offset: 0
         }


### PR DESCRIPTION
Adding support for the search param `fields`, https://developer.box.com/reference/get-search/#param-fields

From the docs:
fields `string array` in query optional
example
id,type,name
A comma-separated list of attributes to include in the response. This can be used to request fields that are not normally returned in a standard response.

Be aware that specifying this parameter will have the effect that none of the standard fields are returned in the response unless explicitly specified, instead only fields for the mini representation are returned, additional to the fields requested.