### PR TITLE
Fix fetching too many folder collaborations

### DIFF
--- a/lib/boxr/collaborations.rb
+++ b/lib/boxr/collaborations.rb
@@ -1,11 +1,13 @@
 module Boxr
   class Client
 
-    def folder_collaborations(folder, fields: [], offset: 0, limit: DEFAULT_LIMIT)
+    def folder_collaborations(folder, fields: [])
       folder_id = ensure_id(folder)
       query = build_fields_query(fields, COLLABORATION_FIELDS_QUERY)
       uri = "#{FOLDERS_URI}/#{folder_id}/collaborations"
-      collaborations = get_all_with_pagination(uri, query: query, offset: offset, limit: limit)
+
+      collaborations, response = get(uri, query: query)
+      collaborations['entries']
     end
 
     def file_collaborations(file, fields: [], limit: DEFAULT_LIMIT, marker: nil)


### PR DESCRIPTION
Hi,

The List folder collaborations API does not seem to support offset and limit.
https://developer.box.com/reference/get-folders-id-collaborations/

If we specify an offset and limit smaller than total_count for the `folder_collaborations`, the loop in the `get_all_with_pagination` will increase the number of collaborators.

We should use the the `get` method in the `folder_collaborations`.

Thank you!