### PR TITLE
Fix Box V2 webhook signature validation

### DIFF
--- a/lib/boxr/webhook_validator.rb
+++ b/lib/boxr/webhook_validator.rb
@@ -35,9 +35,8 @@ module Boxr
     end
 
     def generate_signature(key)
-      message_as_bytes = (payload.bytes + timestamp.bytes).pack('U')
-      digest = OpenSSL::HMAC.hexdigest('SHA256', key, message_as_bytes)
-      Base64.encode64(digest)
+      digest = OpenSSL::HMAC.digest("SHA256", key, "#{payload}#{timestamp}")
+      Base64.strict_encode64(digest)
     end
 
     private

--- a/lib/boxr/webhook_validator.rb
+++ b/lib/boxr/webhook_validator.rb
@@ -35,7 +35,7 @@ module Boxr
     end
 
     def generate_signature(key)
-      digest = OpenSSL::HMAC.digest("SHA256", key, "#{payload}#{timestamp}")
+      digest = OpenSSL::HMAC.digest('SHA256', key, "#{payload}#{timestamp}")
       Base64.strict_encode64(digest)
     end
 
@@ -48,7 +48,7 @@ module Boxr
     def delivery_time
       Time.parse(timestamp).utc
     rescue ArgumentError
-      raise BoxrError.new(boxr_message: "Webhook authenticity not verified: invalid timestamp")
+      raise BoxrError.new(boxr_message: 'Webhook authenticity not verified: invalid timestamp')
     end
 
     def message_age

--- a/spec/boxr/collaborations_spec.rb
+++ b/spec/boxr/collaborations_spec.rb
@@ -29,7 +29,7 @@ describe 'collaborations operations' do
     puts "inspect folder collaborations"
     collaborations = BOX_CLIENT.folder_collaborations(@test_folder)
     expect(collaborations.count).to eq(2)
-    expect(collaborations[0].id).to eq(COLLABORATION.id)
+    expect(collaborations.map(&:id)).to include(COLLABORATION.id)
 
     puts "inspect file collaborations"
     collaborations = BOX_CLIENT.file_collaborations(new_file)

--- a/spec/boxr/files_spec.rb
+++ b/spec/boxr/files_spec.rb
@@ -87,7 +87,7 @@ describe "file operations" do
     versions = BOX_CLIENT.versions_of_file(test_file)
     expect(versions.count).to eq(3) #this is still 3 because with Box you can restore a trashed old version
 
-    puts "get file thumbnail"
+    puts "get file thumbnail" #FIXME: this transiently fails
     thumb = BOX_CLIENT.thumbnail(test_file)
     expect(thumb).not_to be_nil
 
@@ -96,7 +96,7 @@ describe "file operations" do
     expect(updated_file.shared_link.access).to eq("open")
 
     puts "create password-protected shared link for file"
-    updated_file = BOX_CLIENT.create_shared_link_for_file(test_file, password: 'password')
+    updated_file = BOX_CLIENT.create_shared_link_for_file(test_file, password: 'Password123%')
     expect(updated_file.shared_link.is_password_enabled).to eq(true)
 
     puts "disable shared link for file"

--- a/spec/boxr/folders_spec.rb
+++ b/spec/boxr/folders_spec.rb
@@ -28,7 +28,7 @@ describe "folder operations" do
     expect(updated_folder.shared_link.access).to eq("open")
 
     puts "create password-protected shared link for folder"
-    updated_folder = BOX_CLIENT.create_shared_link_for_folder(@test_folder, password: 'password')
+    updated_folder = BOX_CLIENT.create_shared_link_for_folder(@test_folder, password: 'Password123%')
     expect(updated_folder.shared_link.is_password_enabled).to eq(true)
     shared_link = updated_folder.shared_link.url
 

--- a/spec/boxr/webhook_validator_spec.rb
+++ b/spec/boxr/webhook_validator_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 def generate_signature(payload, timestamp, key)
-  message_as_bytes = (payload.bytes + timestamp.bytes).pack('U')
-  digest = OpenSSL::HMAC.hexdigest('SHA256', key, message_as_bytes)
-  Base64.encode64(digest)
+  digest = OpenSSL::HMAC.digest('SHA256', key, "#{payload}#{timestamp}")
+  Base64.strict_encode64(digest)
 end
 
 # rake spec SPEC_OPTS="-e \"Boxr::WebhookValidator"\"
@@ -32,7 +31,7 @@ describe Boxr::WebhookValidator, :skip_reset do
       it 'raises an error' do
         expect do
           subject
-        end.to raise_error(RuntimeError, 'Webhook authenticity not verified: invalid timestamp')
+        end.to raise_error(Boxr::BoxrError, 'Webhook authenticity not verified: invalid timestamp')
       end
     end
 
@@ -41,7 +40,7 @@ describe Boxr::WebhookValidator, :skip_reset do
       it 'raises an error' do
         expect do
           subject
-        end.to raise_error(RuntimeError, 'Webhook authenticity not verified: invalid timestamp')
+        end.to raise_error(Boxr::BoxrError, 'Webhook authenticity not verified: invalid timestamp')
       end
     end
   end


### PR DESCRIPTION
This fixes #127.

Outside of the "update task assignment" assertion that requires the test user to confirm their email, I've managed to get all the specs to pass by doing the following:
1. Update `webhook_validator_spec.rb` to use the updated signature generation
2. Updated passwords in `files_spec.rb` and `folders_spec.rb` to comply with updated password complexity requirements

Also, the thumbnail test transiently fails, so I added a comment to it.