### PR TITLE
Update minimum version of addressable gem to address CVE

### DIFF
--- a/boxr.gemspec
+++ b/boxr.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_development_dependency "bundler", "~> 2.3"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.1"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "simplecov", "~> 0.9"
-  spec.add_development_dependency "dotenv", "~> 0.11"
+  spec.add_development_dependency "dotenv", "~> 2.8"
   spec.add_development_dependency "awesome_print", "~> 1.8"
-  spec.add_development_dependency "lru_redux", "~> 0.8"
+  spec.add_development_dependency "lru_redux", "~> 1.1"
   spec.add_development_dependency "parallel", "~> 1.0"
   spec.add_development_dependency "rubyzip", "~> 2.3"
 

--- a/boxr.gemspec
+++ b/boxr.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "httpclient", "~> 2.8"
   spec.add_runtime_dependency "hashie", ">= 3.5", "< 6"
-  spec.add_runtime_dependency "addressable", "~> 2.3"
+  spec.add_runtime_dependency "addressable", "~> 2.8"
   spec.add_runtime_dependency "jwt", ">= 1.4", "< 3"
 end


### PR DESCRIPTION
This closes #128. Because of semver, most installs in the last few years seem to be fine, but it's probably a good idea to bump the minimum version.

I've also updated the development dependencies to support Ruby 3+ (tested on 3.2.2).

Specs all pass contingent on the fixes here: https://github.com/cburnette/boxr/pull/129.