### PR TITLE
Fix bug when commit session API endpoint returns 202 HTTP status code

### DIFF
--- a/lib/boxr/version.rb
+++ b/lib/boxr/version.rb
@@ -1,3 +1,3 @@
 module Boxr
-  VERSION = "1.21.1".freeze
+  VERSION = "1.21.2".freeze
 end


### PR DESCRIPTION
**Problem**

Sometimes when we commit chunked uploads session Box API responds with 202 HTTP status code. In this case Box response is empty so parsed response is nil and we get an error when we try to read from parsed response:

https://github.com/casperbrike/boxr/blob/f71a97ba8f79bffb3bd3c36defb945ac17d8e081/lib/boxr/chunked_uploads.rb#L196-L198

**Tech changes**

- Added a method `with_retry_on_202` that yields a block (expecting that a call to Box API will passed in a block), checks response status, if it's 202 then sleeps for value specified in `retry-after` response header (as Box' documentation recommends): https://developer.box.com/guides/uploads/chunked/commit-session/ 
- Wrapped commit chunked upload session API call into `with_retry_on_202`
