### PR TITLE
Uninstall lru_redux and install sin_lru_redux

### DIFF
--- a/boxr.gemspec
+++ b/boxr.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.9"
   spec.add_development_dependency "dotenv", "~> 2.8"
   spec.add_development_dependency "awesome_print", "~> 1.8"
-  spec.add_development_dependency "lru_redux", "~> 1.1"
+  spec.add_development_dependency "sin_lru_redux", "~> 2.5"
   spec.add_development_dependency "parallel", "~> 1.0"
   spec.add_development_dependency "rubyzip", "~> 2.3"
 

--- a/examples/user_events.rb
+++ b/examples/user_events.rb
@@ -4,10 +4,10 @@ require 'awesome_print'
 require 'lru_redux'
 
 client = Boxr::Client.new(ENV['BOX_DEVELOPER_TOKEN'])
-cache = LruRedux::Cache.new(1000)
+cache = LruRedux::Cache.new(1000, true)
 
 stream_position = :now
-loop do 
+loop do
   puts "fetching events..."
   event_response = client.user_events(stream_position)
   event_response.events.each do |event|


### PR DESCRIPTION
## What's changed

- Uninstall `lru_redux` and install `sin_lru_redux` because `lru_redux` has not been maintained for over 10 years
- Set ignore_nil argument to true for saving memory
